### PR TITLE
Wrong return signature of `VotingEnsemble.fit`

### DIFF
--- a/etna/ensembles/voting_ensemble.py
+++ b/etna/ensembles/voting_ensemble.py
@@ -32,6 +32,15 @@ class VotingEnsemble(Pipeline):
     ...     weights=[0.7, 0.3]
     ... )
     >>> ensemble.fit(ts=ts)
+    VotingEnsemble(pipelines =
+    [Pipeline(model = ProphetModel(growth = 'linear', changepoints = None, n_changepoints = 25,
+    changepoint_range = 0.8, yearly_seasonality = 'auto', weekly_seasonality = 'auto',
+    daily_seasonality = 'auto', holidays = None, seasonality_mode = 'additive',
+    seasonality_prior_scale = 10.0, holidays_prior_scale = 10.0, mcmc_samples = 0,
+    interval_width = 0.8, uncertainty_samples = 1000, stan_backend = None,
+    additional_seasonality_params = (), ), transforms = [], horizon = 7, ),
+    Pipeline(model = NaiveModel(lag = 10, ), transforms = [], horizon = 7, )],
+    weights = [0.7, 0.3], n_jobs = 1, )
     >>> forecast = ensemble.forecast()
     >>> forecast
     segment         segment_0        segment_1       segment_2


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna-ts/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna-ts/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Add `return self` at the end of `fit` method.

## Related Issue
#184.

## Closing issues
Closes #184.
