### PR TITLE
Changes tests to keep consistency with #313

### DIFF
--- a/tests/test_ensembles/test_stacking_ensemble.py
+++ b/tests/test_ensembles/test_stacking_ensemble.py
@@ -38,7 +38,7 @@ def test_get_horizon_fail(catboost_pipeline: Pipeline, naive_pipeline: Pipeline)
 @pytest.mark.parametrize("input_cv,true_cv", ([(2, 2)]))
 def test_cv_pass(naive_pipeline_1: Pipeline, naive_pipeline_2: Pipeline, input_cv, true_cv):
     """Check that StackingEnsemble._validate_cv works correctly in case of valid cv parameter."""
-    ensemble = StackingEnsemble(pipelines=[naive_pipeline_1, naive_pipeline_2], cv=input_cv)
+    ensemble = StackingEnsemble(pipelines=[naive_pipeline_1, naive_pipeline_2], n_folds=input_cv)
     assert ensemble.cv == true_cv
 
 
@@ -46,7 +46,7 @@ def test_cv_pass(naive_pipeline_1: Pipeline, naive_pipeline_2: Pipeline, input_c
 def test_cv_fail_wrong_number(naive_pipeline_1: Pipeline, naive_pipeline_2: Pipeline, input_cv):
     """Check that StackingEnsemble._validate_cv works correctly in case of wrong number for cv parameter."""
     with pytest.raises(ValueError, match="At least two folds for backtest are expected."):
-        _ = StackingEnsemble(pipelines=[naive_pipeline_1, naive_pipeline_2], cv=input_cv)
+        _ = StackingEnsemble(pipelines=[naive_pipeline_1, naive_pipeline_2], n_folds=input_cv)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #313 to close #290

I haven't been able to find any tests for `pipeline` that use the parameter `n_folds`, but if there is anything wrong, I'll be glad to help fix it.