### PR TITLE
Speed up `Pipelinet._get_backtest_forecasts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add `ts.inverse_transform` as final step at `Pipeline.fit` method ([#316](https://github.com/tinkoff-ai/etna/pull/316))
 - Make test_ts optional in plot_forecast ([#321](https://github.com/tinkoff-ai/etna/pull/321))
+- Speed up Pipeline._get_backtest_forecasts ([#336](https://github.com/tinkoff-ai/etna/pull/336))
 
 ## [1.3.3] - 2021-11-24
 ### Added

--- a/etna/pipeline/pipeline.py
+++ b/etna/pipeline/pipeline.py
@@ -302,9 +302,7 @@ class Pipeline(BasePipeline):
             forecast = forecast_ts.df
             fold_number_df = pd.DataFrame(
                 np.tile(fold_number, (forecast.index.shape[0], len(segments))),
-                columns=pd.MultiIndex.from_product(
-                    [segments, [self._fold_column]], names=("segment", "feature")
-                ),
+                columns=pd.MultiIndex.from_product([segments, [self._fold_column]], names=("segment", "feature")),
                 index=forecast.index,
             )
             forecast = forecast.join(fold_number_df)

--- a/etna/pipeline/pipeline.py
+++ b/etna/pipeline/pipeline.py
@@ -295,7 +295,7 @@ class Pipeline(BasePipeline):
 
     def _get_backtest_forecasts(self) -> pd.DataFrame:
         """Get forecasts from different folds."""
-        stacked_forecast = pd.DataFrame()
+        forecasts_list = []
         for fold_number, fold_info in self._folds.items():
             forecast_ts = fold_info["forecast"]
             segments = forecast_ts.segments
@@ -306,8 +306,9 @@ class Pipeline(BasePipeline):
                 index=forecast.index,
             )
             forecast = forecast.join(fold_number_df)
-            stacked_forecast = stacked_forecast.append(forecast)
-        return stacked_forecast
+            forecasts_list.append(forecast)
+        forecasts = pd.concat(forecasts_list)
+        return forecasts
 
     def backtest(
         self,

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from datetime import datetime
 from typing import List
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -345,3 +346,50 @@ def test_backtest_with_n_jobs(catboost_pipeline: Pipeline, big_example_tsdf: TSD
     _, forecast_1, _ = pipeline_1.backtest(ts=ts1, n_jobs=1, metrics=DEFAULT_METRICS)
     _, forecast_2, _ = pipeline_2.backtest(ts=ts2, n_jobs=3, metrics=DEFAULT_METRICS)
     assert (forecast_1 == forecast_2).all().all()
+
+
+@pytest.fixture
+def step_ts() -> Tuple[TSDataset, pd.DataFrame, pd.DataFrame]:
+    horizon = 5
+    n_folds = 3
+    train_size = 20
+    start_value = 10.0
+    add_value = 5.0
+    segment = 0
+    timestamp = pd.date_range(start="2020-01-01", periods=train_size + n_folds * horizon, freq="D")
+    target = [start_value] * train_size
+    for i in range(n_folds):
+        target += [target[-1] + add_value] * horizon
+
+    df = pd.DataFrame({"timestamp": timestamp, "target": target, "segment": 0})
+    ts = TSDataset(TSDataset.to_dataset(df), freq="D")
+
+    metrics_df = pd.DataFrame(
+        {"segment": [segment, segment, segment], "MAE": [add_value, add_value, add_value], "fold_number": [0, 1, 2]}
+    )
+
+    timestamp_forecast = timestamp[train_size:]
+    target_forecast = []
+    fold_number_forecast = []
+    for i in range(n_folds):
+        target_forecast += [start_value + i * add_value] * horizon
+        fold_number_forecast += [i] * horizon
+    forecast_df = pd.DataFrame(
+        {"target": target_forecast, "fold_number": fold_number_forecast},
+        index=timestamp_forecast,
+    )
+    forecast_df.columns = pd.MultiIndex.from_product(
+        [[segment], ["target", "fold_number"]], names=("segment", "feature")
+    )
+
+    return ts, metrics_df, forecast_df
+
+
+def test_backtest_forecasts_sanity(step_ts):
+    """Check that Pipeline.backtest gives correct forecasts according to the simple case."""
+    ts, expected_metrics_df, expected_forecast_df = step_ts
+    pipeline = Pipeline(model=NaiveModel(), horizon=5)
+    metrics_df, forecast_df, _ = pipeline.backtest(ts, metrics=[MAE()], n_folds=3)
+
+    assert np.all(metrics_df.reset_index(drop=True) == expected_metrics_df)
+    assert np.all(forecast_df == expected_forecast_df)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Vectorize logic inside `Pipeline._get_backtest_forecasts`.

### Results of benchmark

Asymptotics:

<img width="617" alt="Снимок экрана 2021-11-30 в 17 12 40" src="https://user-images.githubusercontent.com/36005824/144066626-a551f950-eeae-4cf7-a635-33d675e8a908.png">

<img width="586" alt="Снимок экрана 2021-11-30 в 17 12 50" src="https://user-images.githubusercontent.com/36005824/144066753-abd11c8c-9b70-4887-a068-47fc89eef29f.png">

Time:
<img width="502" alt="Снимок экрана 2021-11-30 в 17 11 34" src="https://user-images.githubusercontent.com/36005824/144066176-f4e1729f-ada4-443b-bc37-5306bae58584.png">

<img width="433" alt="Снимок экрана 2021-11-30 в 17 12 22" src="https://user-images.githubusercontent.com/36005824/144066484-2f424af7-62a6-487c-91e4-1c709a5ebcd2.png">

## Related Issue
#322.

## Closing issues
Closes #322.