### PR TITLE
Make `TSDataset.to_flatten` faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 -
 -
--
+- Make TSDataset.to_flatten faster ([#475](https://github.com/tinkoff-ai/etna/pull/475))
 -
 -
 -

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -407,20 +407,22 @@ class TSDataset:
         3 2021-06-04     1.0  segment_0
         4 2021-06-05     1.0  segment_0
         """
+        # flatten dataframe
         aggregator_list = []
-        category = []
         segments = df.columns.get_level_values("segment").unique().tolist()
         for segment in segments:
-            if df[segment].select_dtypes(include=["category"]).columns.to_list():
-                category.extend(df[segment].select_dtypes(include=["category"]).columns.to_list())
             aggregator_list.append(df[segment].copy())
             aggregator_list[-1]["segment"] = segment
-        df = pd.concat(aggregator_list)
-        df = df.reset_index()
-        category = list(set(category))
-        df[category] = df[category].astype("category")
-        df.columns.name = None
-        return df
+        df_flat = pd.concat(aggregator_list)
+        df_flat = df_flat.reset_index()
+        df_flat.columns.name = None
+
+        # mark category as category
+        dtypes = df.dtypes
+        category_columns = dtypes[dtypes == "category"].index.get_level_values(1).unique()
+        df_flat[category_columns] = df_flat[category_columns].astype("category")
+
+        return df_flat
 
     def to_pandas(self, flatten: bool = False) -> pd.DataFrame:
         """Return pandas DataFrame.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Look #472.

## Related Issue
#472.

## Closing issues