### PR TITLE
Fix `TSDataset._update_regressors` to work with filtering features

### DIFF
--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -152,7 +152,11 @@ class TSDataset:
     def _update_regressors(self, transform: "Transform", columns_before: Set[str], columns_after: Set[str]):
         from etna.transforms.base import FutureMixin
 
+        # intersect list of regressors with columns after the transform
+        self._regressors = list(set(self._regressors).intersection(columns_after))
+
         unseen_columns = list(columns_after - columns_before)
+
         if len(unseen_columns) == 0:
             return
 

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -9,6 +9,7 @@ import pytest
 from etna.datasets import generate_ar_df
 from etna.datasets.tsdataset import TSDataset
 from etna.transforms import AddConstTransform
+from etna.transforms import FilterFeaturesTransform
 from etna.transforms import LagTransform
 from etna.transforms import MaxAbsScalerTransform
 from etna.transforms import SegmentEncoderTransform
@@ -566,5 +567,23 @@ def test_update_regressors_with_regressor_in_column(ts_with_regressors, transfor
     ),
 )
 def test_update_regressors_not_add_not_regressors(ts_with_regressors, transforms, expected_regressors):
+    _test_update_regressors_transform(deepcopy(ts_with_regressors), deepcopy(transforms), expected_regressors)
+    _test_update_regressors_fit_transform(deepcopy(ts_with_regressors), deepcopy(transforms), expected_regressors)
+
+
+@pytest.mark.parametrize(
+    "transforms, expected_regressors",
+    (
+        (
+            [FilterFeaturesTransform(exclude=["regressor_1"])],
+            ["regressor_2"],
+        ),
+        (
+            [FilterFeaturesTransform(exclude=["regressor_1", "regressor_2"])],
+            [],
+        ),
+    ),
+)
+def test_update_regressors_after_filter(ts_with_regressors, transforms, expected_regressors):
     _test_update_regressors_transform(deepcopy(ts_with_regressors), deepcopy(transforms), expected_regressors)
     _test_update_regressors_fit_transform(deepcopy(ts_with_regressors), deepcopy(transforms), expected_regressors)

--- a/tests/test_transforms/test_feature_importance_transform.py
+++ b/tests/test_transforms/test_feature_importance_transform.py
@@ -181,7 +181,6 @@ def test_sanity_selected(model, ts_with_regressors):
     assert len(useful_regressors) == 3
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Look #444.

## Related Issue
#444.

## Closing issues
Closes #444.