### PR TITLE
Remove unnecessary levels from multiindex columns to fix `DifferencingTransform.inverse_transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 -
 -
--
+- Bug with exog features in DifferencingTransform.inverse_transform ([#503](https://github.com/tinkoff-ai/etna/pull/503))
 -
 -
 -

--- a/etna/transforms/math/differencing.py
+++ b/etna/transforms/math/differencing.py
@@ -96,6 +96,8 @@ class _SingleDifferencingTransform(Transform):
 
             self._train_init_dict[current_segment] = cur_series[: self.period]
         self._test_init_df = fit_df.iloc[-self.period :, :]
+        # make multiindex levels consistent
+        self._test_init_df.columns = self._test_init_df.columns.remove_unused_levels()
         return self
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Look #499.

## Related Issue
#499.

## Closing issues
Closes #499.