### PR TITLE
Fix `get_centroids` returned dataframe columns

### DIFF
--- a/etna/clustering/hierarchical/base.py
+++ b/etna/clustering/hierarchical/base.py
@@ -143,6 +143,11 @@ class HierarchicalClustering(Clustering):
             centroids.append(centroid)
         self.centroids_df = pd.concat(centroids, ignore_index=True)
         self.centroids_df = TSDataset.to_dataset(self.centroids_df)
+
+        # modify dataframe columns
+        columns_frame = self.centroids_df.columns.to_frame()
+        columns_frame["segment"] = columns_frame["segment"].astype(int)
+        self.centroids_df.columns = pd.MultiIndex.from_frame(columns_frame)
         self.centroids_df.columns.set_names("cluster", level=0, inplace=True)
         return self.centroids_df
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [ ] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Change column type of level 0.