### PR TITLE
Fix making backtest if all segments start with NaNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - Fix tiny prediction intervals ([#722](https://github.com/tinkoff-ai/etna/pull/722))
 - 
-- 
+- Fix making backtest if all segments start with NaNs ([#728](https://github.com/tinkoff-ai/etna/pull/728))
 - 
 
 ## [1.9.0] - 2022-05-17

--- a/etna/pipeline/base.py
+++ b/etna/pipeline/base.py
@@ -88,7 +88,7 @@ class FoldMask(BaseMixin):
         dataset_timestamps = list(ts.index)
         dataset_description = ts.describe()
 
-        min_first_timestamp = dataset_description["start_timestamp"].min()
+        min_first_timestamp = ts.index.min()
         if self.first_train_timestamp and self.first_train_timestamp < min_first_timestamp:
             raise ValueError(f"First train timestamp should be later than {min_first_timestamp}!")
 

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -172,13 +172,37 @@ def step_ts() -> Tuple[TSDataset, pd.DataFrame, pd.DataFrame]:
     return ts, metrics_df, forecast_df
 
 
-@pytest.fixture
-def simple_ts() -> TSDataset:
+def _get_simple_df() -> pd.DataFrame:
     timerange = pd.date_range(start="2020-01-01", periods=10).to_list()
     df = pd.DataFrame({"timestamp": timerange + timerange})
     df["segment"] = ["segment_0"] * 10 + ["segment_1"] * 10
     df["target"] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    return df
+
+
+@pytest.fixture
+def simple_ts() -> TSDataset:
+    df = _get_simple_df()
     df = TSDataset.to_dataset(df)
+    ts = TSDataset(df, freq="D")
+    return ts
+
+
+@pytest.fixture
+def simple_ts_starting_with_nans_one_segment(simple_ts) -> TSDataset:
+    df = _get_simple_df()
+    df = TSDataset.to_dataset(df)
+    df.iloc[:2, 0] = np.NaN
+    ts = TSDataset(df, freq="D")
+    return ts
+
+
+@pytest.fixture
+def simple_ts_starting_with_nans_all_segments(simple_ts) -> TSDataset:
+    df = _get_simple_df()
+    df = TSDataset.to_dataset(df)
+    df.iloc[:2, 0] = np.NaN
+    df.iloc[:3, 1] = np.NaN
     ts = TSDataset(df, freq="D")
     return ts
 

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -510,3 +510,16 @@ def test_sanity_backtest_naive_with_intervals(weekly_period_ts):
     features = forecast_df.columns.get_level_values(1)
     assert f"target_{quantiles[0]}" in features
     assert f"target_{quantiles[1]}" in features
+
+
+@pytest.mark.parametrize(
+    "ts_name", ["simple_ts_starting_with_nans_one_segment", "simple_ts_starting_with_nans_all_segments"]
+)
+def test_backtest_nans_at_beginning(ts_name, request):
+    ts = request.getfixturevalue(ts_name)
+    pipeline = Pipeline(model=NaiveModel(), horizon=2)
+    _ = pipeline.backtest(
+        ts=ts,
+        metrics=[MAE()],
+        n_folds=2,
+    )

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -523,3 +523,21 @@ def test_backtest_nans_at_beginning(ts_name, request):
         metrics=[MAE()],
         n_folds=2,
     )
+
+
+@pytest.mark.parametrize(
+    "ts_name", ["simple_ts_starting_with_nans_one_segment", "simple_ts_starting_with_nans_all_segments"]
+)
+def test_backtest_nans_at_beginning_with_mask(ts_name, request):
+    ts = request.getfixturevalue(ts_name)
+    mask = FoldMask(
+        ts.index.min(),
+        ts.index.min() + np.timedelta64(5, "D"),
+        [ts.index.min() + np.timedelta64(6, "D"), ts.index.min() + np.timedelta64(8, "D")],
+    )
+    pipeline = Pipeline(model=NaiveModel(), horizon=3)
+    _ = pipeline.backtest(
+        ts=ts,
+        metrics=[MAE()],
+        n_folds=[mask],
+    )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
Look #725.

## Related Issue
#725.

## Closing issues
Closes #725.