### PR TITLE
FIX: deepcopy for fitted deepmodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - Fix tiny prediction intervals ([#722](https://github.com/tinkoff-ai/etna/pull/722))
 - 
-- 
+- Fix deepcopy issue for fitted deepmodel ([#735](https://github.com/tinkoff-ai/etna/pull/735))
 - 
 
 ## [1.9.0] - 2022-05-17

--- a/etna/models/nn/deepar.py
+++ b/etna/models/nn/deepar.py
@@ -11,6 +11,7 @@ from etna.datasets.tsdataset import TSDataset
 from etna.loggers import tslogger
 from etna.models.base import Model
 from etna.models.base import log_decorator
+from etna.models.nn.utils import _DeepCopyMixin
 from etna.transforms import PytorchForecastingTransform
 
 if SETTINGS.torch_required:
@@ -20,7 +21,7 @@ if SETTINGS.torch_required:
     from pytorch_lightning import LightningModule
 
 
-class DeepARModel(Model):
+class DeepARModel(Model, _DeepCopyMixin):
     """Wrapper for :py:class:`pytorch_forecasting.models.deepar.DeepAR`.
 
     Notes

--- a/etna/models/nn/tft.py
+++ b/etna/models/nn/tft.py
@@ -11,6 +11,7 @@ from etna.datasets.tsdataset import TSDataset
 from etna.loggers import tslogger
 from etna.models.base import Model
 from etna.models.base import log_decorator
+from etna.models.nn.utils import _DeepCopyMixin
 from etna.transforms import PytorchForecastingTransform
 
 if SETTINGS.torch_required:
@@ -20,7 +21,7 @@ if SETTINGS.torch_required:
     from pytorch_lightning import LightningModule
 
 
-class TFTModel(Model):
+class TFTModel(Model, _DeepCopyMixin):
     """Wrapper for :py:class:`pytorch_forecasting.models.temporal_fusion_transformer.TemporalFusionTransformer`.
 
     Notes

--- a/etna/models/nn/utils.py
+++ b/etna/models/nn/utils.py
@@ -2,10 +2,10 @@ from copy import deepcopy
 
 
 class _DeepCopyMixin:
-    """Mixin for `__deepcopy__` behaviour overriding."""
+    """Mixin for ``__deepcopy__`` behaviour overriding."""
 
     def __deepcopy__(self, memo):
-        """Drop `model` and `trainer` attributes while deepcopy."""
+        """Drop ``model`` and ``trainer`` attributes while deepcopy."""
         cls = self.__class__
         obj = cls.__new__(cls)
         memo[id(self)] = obj

--- a/etna/models/nn/utils.py
+++ b/etna/models/nn/utils.py
@@ -1,0 +1,14 @@
+from copy import deepcopy
+
+
+class _DeepCopyMixin:
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        memo[id(self)] = obj
+        for k, v in self.__dict__.items():
+            if k in ["model", "trainer"]:
+                v = dict()
+            setattr(obj, k, deepcopy(v, memo))
+            pass
+        return obj

--- a/etna/models/nn/utils.py
+++ b/etna/models/nn/utils.py
@@ -2,7 +2,10 @@ from copy import deepcopy
 
 
 class _DeepCopyMixin:
+    """Mixin for `__deepcopy__` behaviour overriding."""
+
     def __deepcopy__(self, memo):
+        """Drop `model` and `trainer` attributes while deepcopy."""
         cls = self.__class__
         obj = cls.__new__(cls)
         memo[id(self)] = obj


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Type of Change
<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] Examples / docs / tutorials / contributors update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

I propose deepcopy behaviour changes for deep models: we dont copy model and trainer attributes

Reason:
* torch.Tensors with attached gradients are not supporting deepcopy protocol. (Only Tensors created explicitly by the user "
                               "(graph leaves) support the deepcopy protocol at the moment")
* we use deepcopy after fit for empirical prediction intervals


## Related Issue
<!-- Link Issue here. -->

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
