### PR TITLE
Make `TSDataset.to_flatten` faster for big datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - 
 - 
-- 
+- Make TSDataset.to_flatten faster for big datasets ([#848](https://github.com/tinkoff-ai/etna/pull/848))
 - 
 - 
 ### Fixed

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -577,7 +577,6 @@ class TSDataset:
         segments = df.columns.get_level_values("segment").unique()
         df_dict = {}
         df_dict["timestamp"] = np.tile(df.index, len(segments))
-        df_dict["segment"] = np.repeat(segments, len(df.index))
         for column in columns:
             df_cur = df.loc[:, pd.IndexSlice[:, column]]
             if column in category_columns:
@@ -586,6 +585,7 @@ class TSDataset:
                 stacked = df_cur.values.T.ravel()
                 # creating series is necessary for dtypes like "Int64", "boolean", otherwise they will be objects
                 df_dict[column] = pd.Series(stacked, dtype=df_cur.dtypes[0])
+        df_dict["segment"] = np.repeat(segments, len(df.index))
         df_flat = pd.DataFrame(df_dict)
 
         return df_flat

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -602,15 +602,24 @@ def test_to_flatten_simple(example_df):
 def test_to_flatten_with_exog(df_and_regressors_flat):
     """Check that TSDataset.to_flatten works correctly with exogenous features."""
     df, df_exog = df_and_regressors_flat
-    # add a category type
+
+    # add boolean dtype
+    df_exog["regressor_boolean"] = 1
+    df_exog["regressor_boolean"] = df_exog["regressor_boolean"].astype("boolean")
+    # add Int64 dtype
+    df_exog["regressor_Int64"] = 1
+    df_exog.loc[1, "regressor_Int64"] = None
+    df_exog["regressor_Int64"] = df_exog["regressor_Int64"].astype("Int64")
+
+    # construct expected result
     flat_df = pd.merge(left=df, right=df_exog, left_on=["timestamp", "segment"], right_on=["timestamp", "segment"])
     sorted_columns = sorted(flat_df.columns)
     expected_df = flat_df[sorted_columns]
     # add values to absent timestamps at one segment
     to_append = pd.DataFrame({"timestamp": df["timestamp"][:5], "segment": ["2"] * 5})
     expected_df = pd.concat((expected_df, to_append)).sort_values(by=["segment", "timestamp"]).reset_index(drop=True)
-    # rebuild category type according to new values
 
+    # get to_flatten result
     obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))[sorted_columns].sort_values(
         by=["segment", "timestamp"]
     )

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -617,7 +617,13 @@ def test_to_flatten_with_exog(df_and_regressors_flat):
     expected_df = flat_df[sorted_columns]
     # add values to absent timestamps at one segment
     to_append = pd.DataFrame({"timestamp": df["timestamp"][:5], "segment": ["2"] * 5})
+    dtypes = expected_df.dtypes.to_dict()
     expected_df = pd.concat((expected_df, to_append)).sort_values(by=["segment", "timestamp"]).reset_index(drop=True)
+    # restore category dtypes: needed for old versions of pandas
+    for column, dtype in dtypes.items():
+        if dtype == "category":
+            expected_df[column] = expected_df[column].astype(dtype)
+
 
     # get to_flatten result
     obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))[sorted_columns].sort_values(

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -624,7 +624,6 @@ def test_to_flatten_with_exog(df_and_regressors_flat):
         if dtype == "category":
             expected_df[column] = expected_df[column].astype(dtype)
 
-
     # get to_flatten result
     obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))[sorted_columns].sort_values(
         by=["segment", "timestamp"]


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #781.

## Closing issues
Closes #781.
Closes #777.