### PR TITLE
Fix native networks to work with generated future equals to horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 -
--
+- Fix native networks to work with generated future equals to horizon ([#936](https://github.com/tinkoff-ai/etna/pull/936))
 -
 -
 

--- a/etna/models/base.py
+++ b/etna/models/base.py
@@ -796,7 +796,7 @@ class DeepBaseModel(FitAbstractModel, DeepBaseAbstractModel, BaseMixin):
         """
         test_dataset = ts.to_torch_dataset(
             make_samples=functools.partial(
-                self.net.make_samples, encoder_length=self.encoder_length, decoder_length=self.decoder_length
+                self.net.make_samples, encoder_length=self.encoder_length, decoder_length=horizon
             ),
             dropna=False,
         )

--- a/etna/pipeline/pipeline.py
+++ b/etna/pipeline/pipeline.py
@@ -55,7 +55,7 @@ class Pipeline(BasePipeline):
             raise ValueError("Something went wrong, ts is None!")
 
         if isinstance(self.model, DeepBaseModel):
-            future = self.ts.make_future(future_steps=self.model.decoder_length, tail_steps=self.model.encoder_length)
+            future = self.ts.make_future(future_steps=self.horizon, tail_steps=self.model.encoder_length)
             predictions = self.model.forecast(ts=future, horizon=self.horizon)
         else:
             future = self.ts.make_future(self.horizon)

--- a/tests/test_models/nn/test_mlp.py
+++ b/tests/test_models/nn/test_mlp.py
@@ -14,7 +14,14 @@ from etna.transforms import LagTransform
 from etna.transforms import StandardScalerTransform
 
 
-@pytest.mark.parametrize("horizon", [8, 13])
+@pytest.mark.parametrize(
+    "horizon",
+    [
+        8,
+        13,
+        15,
+    ],
+)
 def test_mlp_model_run_weekly_overfit_with_scaler(ts_dataset_weekly_function_with_horizon, horizon):
 
     ts_train, ts_test = ts_dataset_weekly_function_with_horizon(horizon)
@@ -31,7 +38,7 @@ def test_mlp_model_run_weekly_overfit_with_scaler(ts_dataset_weekly_function_wit
         decoder_length=decoder_length,
         trainer_params=dict(max_epochs=100),
     )
-    future = ts_train.make_future(decoder_length)
+    future = ts_train.make_future(horizon)
     model.fit(ts_train)
     future = model.forecast(future, horizon=horizon)
 

--- a/tests/test_models/nn/test_rnn.py
+++ b/tests/test_models/nn/test_rnn.py
@@ -10,7 +10,14 @@ from etna.transforms import StandardScalerTransform
 
 
 @pytest.mark.long_2
-@pytest.mark.parametrize("horizon", [8, 13])
+@pytest.mark.parametrize(
+    "horizon",
+    [
+        8,
+        13,
+        15,
+    ],
+)
 def test_rnn_model_run_weekly_overfit_with_scaler(ts_dataset_weekly_function_with_horizon, horizon):
     """
     Given: I have dataframe with 2 segments with weekly seasonality with known future
@@ -28,7 +35,7 @@ def test_rnn_model_run_weekly_overfit_with_scaler(ts_dataset_weekly_function_wit
     model = RNNModel(
         input_size=1, encoder_length=encoder_length, decoder_length=decoder_length, trainer_params=dict(max_epochs=100)
     )
-    future = ts_train.make_future(decoder_length, encoder_length)
+    future = ts_train.make_future(horizon, encoder_length)
     model.fit(ts_train)
     future = model.forecast(future, horizon=horizon)
 


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
1. Pass `horizon` instead of `decoder_length` in `forecast`.
2. Call `make_future` with `decoder_length` in pipeline
3. Fix tests for native networks.

## Closing issues
Closes #925.