### PR TITLE
Remove documentation warning about using pickle in saving/loading catboost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix release docs and docker images cron job ([#982](https://github.com/tinkoff-ai/etna/pull/982))
 -
 -
--
+- Remove documentation warning about using pickle in saving/loading catboost ([#1020](https://github.com/tinkoff-ai/etna/pull/1020))
 -
 ## [1.13.0] - 2022-10-10
 ### Added

--- a/etna/models/catboost.py
+++ b/etna/models/catboost.py
@@ -115,8 +115,6 @@ class CatBoostPerSegmentModel(
 ):
     """Class for holding per segment Catboost model.
 
-    Currently, pickle is used in ``save`` and  ``load`` methods. It can work unreliably.
-
     Examples
     --------
     >>> from etna.datasets import generate_periodic_df
@@ -242,11 +240,6 @@ class CatBoostMultiSegmentModel(
     NonPredictionIntervalContextIgnorantAbstractModel,
 ):
     """Class for holding Catboost model for all segments.
-
-    Warning
-    -------
-    Currently, pickle is used in ``save`` and  ``load`` methods. It can work unreliably, because
-    there is a native method :py:meth:`catboost.CatBoost.save_model`.
 
     Examples
     --------

--- a/tests/test_models/test_catboost.py
+++ b/tests/test_models/test_catboost.py
@@ -130,7 +130,6 @@ def test_encoder_catboost(encoder):
     _ = pipeline.backtest(ts=ts, metrics=[MAE()], n_folds=1)
 
 
-@pytest.mark.xfail(reason="Non native serialization, should be fixed in inference-v2.0")
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Remove warning about using pickle in saving/loading catboost. Catboost already has valid `__getstate__` and `__setstate__` and should work fine with pickle.

## Closing issues
