### PR TITLE
Issue-1078: missed kwargs in TFT init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 ### Fixed
 -
--
+- Missed kwargs in TFT init([#1078](https://github.com/tinkoff-ai/etna/pull/1078))
 -
 -
 -

--- a/etna/models/nn/tft.py
+++ b/etna/models/nn/tft.py
@@ -53,7 +53,6 @@ class TFTModel(_DeepCopyMixin, SaveNNMixin, PredictionIntervalContextIgnorantAbs
         loss: "MultiHorizonMetric" = None,
         trainer_kwargs: Optional[Dict[str, Any]] = None,
         quantiles_kwargs: Optional[Dict[str, Any]] = None,
-        *args,
         **kwargs,
     ):
         """

--- a/etna/models/nn/tft.py
+++ b/etna/models/nn/tft.py
@@ -113,6 +113,7 @@ class TFTModel(_DeepCopyMixin, SaveNNMixin, PredictionIntervalContextIgnorantAbs
         self.trainer: Optional[pl.Trainer] = None
         self._last_train_timestamp = None
         self._freq: Optional[str] = None
+        self.kwargs = kwargs
 
     def _from_dataset(self, ts_dataset: TimeSeriesDataSet) -> LightningModule:
         """

--- a/tests/test_core/test_to_dict.py
+++ b/tests/test_core/test_to_dict.py
@@ -17,6 +17,7 @@ from etna.models import CatBoostModelPerSegment
 from etna.models import LinearPerSegmentModel
 from etna.models.nn import DeepARModel
 from etna.models.nn import MLPModel
+from etna.models.nn import TFTModel
 from etna.pipeline import Pipeline
 from etna.transforms import AddConstTransform
 from etna.transforms import ChangePointsTrendTransform
@@ -98,10 +99,11 @@ def test_to_dict_transforms_with_expected(target_object, expected):
 @pytest.mark.parametrize(
     "target_model",
     [
-        pytest.param(DeepARModel(), marks=pytest.mark.xfail(reason="some bug")),
+        pytest.param(DeepARModel(), marks=pytest.mark.xfail(raises=AssertionError)),
         LinearPerSegmentModel(),
         CatBoostModelPerSegment(),
         AutoARIMAModel(),
+        pytest.param(TFTModel(max_epochs=2), marks=pytest.mark.xfail(raises=AssertionError)),
     ],
 )
 def test_to_dict_models(target_model):

--- a/tests/test_models/nn/test_tft.py
+++ b/tests/test_models/nn/test_tft.py
@@ -187,3 +187,11 @@ def test_save_load(example_tsds):
     transform = _get_default_transform(horizon)
     transforms = [transform]
     assert_model_equals_loaded_original(model=model, ts=example_tsds, transforms=transforms, horizon=horizon)
+
+
+def test_repr():
+    model = TFTModel(max_epochs=2, learning_rate=[0.1], gpus=0, batch_size=64)
+    assert "TFTModel(max_epochs = 2, gpus = 0, gradient_clip_val = 0.1, "
+    "learning_rate = [0.1], batch_size = 64, context_length = None, hidden_size = 16, "
+    "lstm_layers = 1, attention_head_size = 4, dropout = 0.1, hidden_continuous_size = 8, "
+    "loss = QuantileLoss(), trainer_kwargs = {}, quantiles_kwargs = {}, )" == repr(model)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes

I've checked other inits. It seems  TFT is the only model with such issue
## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1078 