### PR TITLE
Fix order of columns after to flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 -
 ### Changed
-
--
+ 
+- Impose specific order of columns after TSDataset.to_flatten ([#873](https://github.com/tinkoff-ai/etna/pull/873))
 -
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 ### Changed
  
-- Impose specific order of columns after TSDataset.to_flatten ([#873](https://github.com/tinkoff-ai/etna/pull/873))
+- Impose specific order of columns on return value of TSDataset.to_flatten ([#873](https://github.com/tinkoff-ai/etna/pull/873))
 -
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 ### Changed
  
-- Impose specific order of columns on return value of TSDataset.to_flatten ([#873](https://github.com/tinkoff-ai/etna/pull/873))
+- Impose specific order of columns on return value of TSDataset.to_flatten ([#1095](https://github.com/tinkoff-ai/etna/pull/1095))
 -
 ### Fixed
 

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -578,6 +578,9 @@ class TSDataset:
     @staticmethod
     def to_flatten(df: pd.DataFrame) -> pd.DataFrame:
         """Return pandas DataFrame with flatten index.
+        
+        The order of columns is (timestamp, segment, target,
+        features in alphabetical order).
 
         Parameters
         ----------
@@ -588,7 +591,6 @@ class TSDataset:
         -------
         pd.DataFrame:
             dataframe with TSDataset data
-            The order of columns is (timestamp, segment, target (if provided), features in alphabetical order).
 
         Examples
         --------
@@ -645,7 +647,9 @@ class TSDataset:
         flatten:
             * If False, return pd.DataFrame with multiindex
 
-            * If True, return with flatten index
+            * If True, return with flatten index,
+            its order of columns is (timestamp, segment, target,
+            features in alphabetical order).
 
         Returns
         -------

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -578,7 +578,7 @@ class TSDataset:
     @staticmethod
     def to_flatten(df: pd.DataFrame) -> pd.DataFrame:
         """Return pandas DataFrame with flatten index.
-        
+
         The order of columns is (timestamp, segment, target,
         features in alphabetical order).
 
@@ -621,12 +621,14 @@ class TSDataset:
         # flatten dataframe
         columns = df.columns.get_level_values("feature").unique()
         segments = df.columns.get_level_values("segment").unique()
-        has_target = "target" in columns
+
         df_dict = {}
         df_dict["timestamp"] = np.tile(df.index, len(segments))
         df_dict["segment"] = np.repeat(segments, len(df.index))
-        if has_target:
-            df_dict["target"] = 0 # will be overwritten in the following cycle
+        if "target" in columns:
+            # set this value to lock position of key "target" in output dataframe columns
+            # None is a placeholder, actual column value will be assigned in the following cycle
+            df_dict["target"] = None
         for column in columns:
             df_cur = df.loc[:, pd.IndexSlice[:, column]]
             if column in category_columns:

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -623,7 +623,7 @@ def test_to_flatten_with_exog(df_and_regressors_flat):
     for column, dtype in dtypes.items():
         if dtype == "category":
             expected_df[column] = expected_df[column].astype(dtype)
-    # this logic woouldn't work in general case, here we use that all features' names start with 'r'
+    # this logic wouldn't work in general case, here we use that all features' names start with 'r'
     sorted_columns = ["timestamp", "segment", "target"] + sorted_columns[:-3]
     # reindex df to assert correct columns order
     expected_df = expected_df[sorted_columns]

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -623,8 +623,10 @@ def test_to_flatten_with_exog(df_and_regressors_flat):
     for column, dtype in dtypes.items():
         if dtype == "category":
             expected_df[column] = expected_df[column].astype(dtype)
+    # this logic woouldn't work in general case, here we use that all features' names start with 'r'
+    sorted_columns = ["timestamp", "segment", "target"] + sorted_columns[:-3]
     # reindex df to assert correct columns order
-    expected_df = expected_df.reindex(columns = ["timestamp", "segment", "target"] + list(expected_df.columns[:5]))
+    expected_df = expected_df[sorted_columns]
     # get to_flatten result
     obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))
     pd.testing.assert_frame_equal(obtained_df, expected_df)

--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -623,14 +623,11 @@ def test_to_flatten_with_exog(df_and_regressors_flat):
     for column, dtype in dtypes.items():
         if dtype == "category":
             expected_df[column] = expected_df[column].astype(dtype)
-
+    # reindex df to assert correct columns order
+    expected_df = expected_df.reindex(columns = ["timestamp", "segment", "target"] + list(expected_df.columns[:5]))
     # get to_flatten result
-    obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))[sorted_columns].sort_values(
-        by=["segment", "timestamp"]
-    )
-    assert np.all(sorted_columns == obtained_df.columns)
-    assert np.all(expected_df.dtypes == obtained_df.dtypes)
-    assert expected_df.equals(obtained_df)
+    obtained_df = TSDataset.to_flatten(TSDataset.to_dataset(flat_df))
+    pd.testing.assert_frame_equal(obtained_df, expected_df)
 
 
 def test_transform_raise_warning_on_diff_endings(ts_diff_endings):


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->
It may be useful to impose the same order on the return dataframe of .to_dataset() for the sake of consistency. Current order of columns in the return dataframe of ._to_dataset() places "target" along other features in alphabetical order.

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #873