### PR TITLE
Fix `MeanSegmentEncoderTransform` to pass inference tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 ### Fixed
 -
--
+- Fix `MeanSegmentEncoderTransform` to work with subset of segments and raise error on new segments ([#1104](https://github.com/tinkoff-ai/etna/pull/1104))
 -
 -
 -

--- a/etna/transforms/encoders/mean_segment_encoder.py
+++ b/etna/transforms/encoders/mean_segment_encoder.py
@@ -1,3 +1,4 @@
+import reprlib
 from typing import Dict
 from typing import Optional
 
@@ -65,11 +66,10 @@ class MeanSegmentEncoderTransform(Transform, FutureMixin):
         new_segments = set(segments) - self.global_means.keys()
         if len(new_segments) > 0:
             raise ValueError(
-                f"This transform can't process segments that weren't present on train data: {new_segments}"
+                f"This transform can't process segments that weren't present on train data: {reprlib.repr(new_segments)}"
             )
 
         df = self.mean_encoder.transform(df)
-        segments = df.columns.get_level_values("segment").unique()
         segment = segments[0]
         nan_timestamps = df[df.loc[:, self.idx[segment, "target"]].isna()].index
         df.loc[nan_timestamps, self.idx[:, "segment_mean"]] = [self.global_means[x] for x in segments]

--- a/etna/transforms/encoders/mean_segment_encoder.py
+++ b/etna/transforms/encoders/mean_segment_encoder.py
@@ -1,4 +1,6 @@
-import numpy as np
+from typing import Dict
+from typing import Optional
+
 import pandas as pd
 
 from etna.transforms import Transform
@@ -13,7 +15,7 @@ class MeanSegmentEncoderTransform(Transform, FutureMixin):
 
     def __init__(self):
         self.mean_encoder = MeanTransform(in_column="target", window=-1, out_column="segment_mean")
-        self.global_means: np.ndarray[float] = None
+        self.global_means: Optional[Dict[str, float]] = None
 
     def fit(self, df: pd.DataFrame) -> "MeanSegmentEncoderTransform":
         """
@@ -30,7 +32,9 @@ class MeanSegmentEncoderTransform(Transform, FutureMixin):
             Fitted transform
         """
         self.mean_encoder.fit(df)
-        self.global_means = df.loc[:, self.idx[:, "target"]].mean().values
+        mean_values = df.loc[:, self.idx[:, "target"]].mean().to_dict()
+        mean_values = {key[0]: value for key, value in mean_values.items()}
+        self.global_means = mean_values
         return self
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -46,9 +50,27 @@ class MeanSegmentEncoderTransform(Transform, FutureMixin):
         -------
         :
             result dataframe
+
+        Raises
+        ------
+        ValueError:
+            If transform isn't fitted.
+        ValueError:
+            If there are segments that weren't present during training.
         """
+        if self.global_means is None:
+            raise ValueError("The transform isn't fitted!")
+
+        segments = df.columns.get_level_values("segment").unique().tolist()
+        new_segments = set(segments) - self.global_means.keys()
+        if len(new_segments) > 0:
+            raise ValueError(
+                f"This transform can't process segments that weren't present on train data: {new_segments}"
+            )
+
         df = self.mean_encoder.transform(df)
-        segment = df.columns.get_level_values("segment").unique()[0]
+        segments = df.columns.get_level_values("segment").unique()
+        segment = segments[0]
         nan_timestamps = df[df.loc[:, self.idx[segment, "target"]].isna()].index
-        df.loc[nan_timestamps, self.idx[:, "segment_mean"]] = self.global_means
+        df.loc[nan_timestamps, self.idx[:, "segment_mean"]] = [self.global_means[x] for x in segments]
         return df


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look at #1101.

## Closing issues
Closes #1101.