### PR TITLE
Fix inference tests on new segments for old NNs

### DIFF
--- a/tests/test_models/test_inference/test_forecast.py
+++ b/tests/test_models/test_inference/test_forecast.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from pandas.util.testing import assert_frame_equal
 from pytorch_forecasting.data import GroupNormalizer
+from pytorch_forecasting.data import NaNLabelEncoder
 from typing_extensions import get_args
 
 from etna.datasets import TSDataset
@@ -879,15 +880,6 @@ class TestForecastNewSegments:
                 MLPModel(input_size=2, hidden_size=[10], decoder_length=7, trainer_params=dict(max_epochs=1)),
                 [LagTransform(in_column="target", lags=[5, 6])],
             ),
-        ],
-    )
-    def test_forecast_new_segments(self, model, transforms, example_tsds):
-        self._test_forecast_new_segments(example_tsds, model, transforms, train_segments=["segment_1"])
-
-    @to_be_fixed(raises=KeyError, match="Unknown category")
-    @pytest.mark.parametrize(
-        "model, transforms",
-        [
             (
                 DeepARModel(max_epochs=1, learning_rate=[0.01]),
                 [
@@ -896,6 +888,7 @@ class TestForecastNewSegments:
                         max_prediction_length=5,
                         time_varying_known_reals=["time_idx"],
                         time_varying_unknown_reals=["target"],
+                        categorical_encoders={"segment": NaNLabelEncoder(add_nan=True, warn=False)},
                         target_normalizer=GroupNormalizer(groups=["segment"]),
                     )
                 ],
@@ -909,6 +902,7 @@ class TestForecastNewSegments:
                         max_prediction_length=5,
                         time_varying_known_reals=["time_idx"],
                         time_varying_unknown_reals=["target"],
+                        categorical_encoders={"segment": NaNLabelEncoder(add_nan=True, warn=False)},
                         static_categoricals=["segment"],
                         target_normalizer=None,
                     )
@@ -916,7 +910,7 @@ class TestForecastNewSegments:
             ),
         ],
     )
-    def test_forecast_new_segments_failed_encoding_error(self, model, transforms, example_tsds):
+    def test_forecast_new_segments(self, model, transforms, example_tsds):
         self._test_forecast_new_segments(example_tsds, model, transforms, train_segments=["segment_1"])
 
     @to_be_fixed(raises=NotImplementedError, match="Per-segment models can't make predictions on new segments")

--- a/tests/test_models/test_inference/test_predict.py
+++ b/tests/test_models/test_inference/test_predict.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from pandas.util.testing import assert_frame_equal
 from pytorch_forecasting.data import GroupNormalizer
+from pytorch_forecasting.data import NaNLabelEncoder
 
 from etna.datasets import TSDataset
 from etna.models import AutoARIMAModel
@@ -782,7 +783,7 @@ class TestPredictNewSegments:
     def test_predict_new_segments(self, model, transforms, example_tsds):
         self._test_predict_new_segments(example_tsds, model, transforms, train_segments=["segment_1"])
 
-    @to_be_fixed(raises=KeyError, match="Unknown category")
+    @to_be_fixed(raises=NotImplementedError, match="Method predict isn't currently implemented")
     @pytest.mark.parametrize(
         "model, transforms",
         [
@@ -794,6 +795,7 @@ class TestPredictNewSegments:
                         max_prediction_length=5,
                         time_varying_known_reals=["time_idx"],
                         time_varying_unknown_reals=["target"],
+                        categorical_encoders={"segment": NaNLabelEncoder(add_nan=True, warn=False)},
                         target_normalizer=GroupNormalizer(groups=["segment"]),
                     )
                 ],
@@ -807,20 +809,12 @@ class TestPredictNewSegments:
                         max_prediction_length=5,
                         time_varying_known_reals=["time_idx"],
                         time_varying_unknown_reals=["target"],
+                        categorical_encoders={"segment": NaNLabelEncoder(add_nan=True, warn=False)},
                         static_categoricals=["segment"],
                         target_normalizer=None,
                     )
                 ],
             ),
-        ],
-    )
-    def test_predict_new_segments_failed_encoding_error(self, model, transforms, example_tsds):
-        self._test_predict_new_segments(example_tsds, model, transforms, train_segments=["segment_1"])
-
-    @to_be_fixed(raises=NotImplementedError, match="Method predict isn't currently implemented")
-    @pytest.mark.parametrize(
-        "model, transforms",
-        [
             (RNNModel(input_size=1, encoder_length=7, decoder_length=7, trainer_params=dict(max_epochs=1)), []),
             (
                 MLPModel(input_size=2, hidden_size=[10], decoder_length=7, trainer_params=dict(max_epochs=1)),


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Set categorical encoder manually, otherwise it is set automatically without option to work with new categories.

## Closing issues
Closes #1088.