### PR TITLE
Make outliers transforms fail on new segments with understandable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 - Fix `SegmentEncoderTransform` to work with subset of segments and raise error on new segments ([#1103](https://github.com/tinkoff-ai/etna/pull/1103))
 - Fix `SklearnTransform` in per-segment mode to work on subset of segments and raise error on new segments ([#1107](https://github.com/tinkoff-ai/etna/pull/1107))
--
+- Fix `OutliersTransform` and its children to raise error on new segments ([#1139](https://github.com/tinkoff-ai/etna/pull/1139))
 ## [1.14.0] - 2022-12-16
 ### Added
 - Add python 3.10 support ([#1005](https://github.com/tinkoff-ai/etna/pull/1005))

--- a/tests/test_transforms/test_inference/test_inverse_transform.py
+++ b/tests/test_transforms/test_inference/test_inverse_transform.py
@@ -674,6 +674,10 @@ class TestInverseTransformTrainNewSegments:
                 TimeSeriesImputerTransform(in_column="target"),
                 "ts_to_fill",
             ),
+            # outliers
+            (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
         ],
     )
     def test_inverse_transform_train_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -704,11 +708,6 @@ class TestInverseTransformTrainNewSegments:
             # math
             # TODO: error should be understandable, not like now
             (DifferencingTransform(in_column="target", inplace=True), "regular_ts", {"change": {"target"}}),
-            # outliers
-            # TODO: error should be understandable, not like now
-            (DensityOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (MedianOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers", {}),
         ],
     )
     def test_inverse_transform_train_new_segments_failed_error(
@@ -1026,6 +1025,10 @@ class TestInverseTransformFutureNewSegments:
                 TimeSeriesImputerTransform(in_column="target"),
                 "ts_to_fill",
             ),
+            # outliers
+            (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
         ],
     )
     def test_inverse_transform_future_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -1081,11 +1084,6 @@ class TestInverseTransformFutureNewSegments:
             # TODO: error should be understandable, not like now
             (DifferencingTransform(in_column="target", inplace=True), "regular_ts", {}),
             (DifferencingTransform(in_column="positive", inplace=True), "ts_with_exog", {"change": {"positive"}}),
-            # outliers
-            # TODO: error should be understandable, not like now
-            (DensityOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (MedianOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers", {}),
         ],
     )
     def test_inverse_transform_future_new_segments_failed_error(

--- a/tests/test_transforms/test_inference/test_transform.py
+++ b/tests/test_transforms/test_inference/test_transform.py
@@ -630,6 +630,10 @@ class TestTransformTrainNewSegments:
                 TimeSeriesImputerTransform(in_column="target"),
                 "ts_to_fill",
             ),
+            # outliers
+            (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
         ],
     )
     def test_transform_train_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -651,23 +655,6 @@ class TestTransformTrainNewSegments:
         ts = request.getfixturevalue(dataset_name)
         self._test_transform_train_new_segments(
             ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
-
-    @to_be_fixed(raises=Exception)
-    @pytest.mark.parametrize(
-        "transform, dataset_name, expected_changes",
-        [
-            # outliers
-            # TODO: error should be understandable, not like now
-            (DensityOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (MedianOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers", {}),
-        ],
-    )
-    def test_transform_train_new_segments_failed_error(self, transform, dataset_name, expected_changes, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_transform_train_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes=expected_changes
         )
 
 
@@ -972,6 +959,10 @@ class TestTransformFutureNewSegments:
                 TimeSeriesImputerTransform(in_column="target"),
                 "ts_to_fill",
             ),
+            # outliers
+            (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
+            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
         ],
     )
     def test_transform_future_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -993,23 +984,6 @@ class TestTransformFutureNewSegments:
         ts = request.getfixturevalue(dataset_name)
         self._test_transform_future_new_segments(
             ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
-
-    @to_be_fixed(raises=Exception)
-    @pytest.mark.parametrize(
-        "transform, dataset_name, expected_changes",
-        [
-            # outliers
-            # TODO: error should be understandable, not like now
-            (DensityOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (MedianOutliersTransform(in_column="target"), "ts_with_outliers", {}),
-            (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers", {}),
-        ],
-    )
-    def test_transform_future_new_segments_failed_error(self, transform, dataset_name, expected_changes, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_transform_future_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes=expected_changes
         )
 
 

--- a/tests/test_transforms/test_outliers/test_outliers_transform.py
+++ b/tests/test_transforms/test_outliers/test_outliers_transform.py
@@ -163,6 +163,46 @@ def test_inverse_transform_raise_error_if_not_fitted(transform, outliers_solid_t
         PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel),
     ),
 )
+def test_transform_new_segments_fail(transform, outliers_solid_tsds):
+    df = outliers_solid_tsds.to_pandas()
+    train_df = df.loc[:, pd.IndexSlice["1", :]]
+    test_df = df.loc[:, pd.IndexSlice["2", :]]
+
+    transform.fit(train_df)
+    with pytest.raises(
+        NotImplementedError, match="This transform can't process segments that weren't present on train data"
+    ):
+        _ = transform.transform(test_df)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    (
+        MedianOutliersTransform(in_column="target"),
+        DensityOutliersTransform(in_column="target"),
+        PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel),
+    ),
+)
+def test_inverse_transform_new_segments_fail(transform, outliers_solid_tsds):
+    df = outliers_solid_tsds.to_pandas()
+    train_df = df.loc[:, pd.IndexSlice["1", :]]
+    test_df = df.loc[:, pd.IndexSlice["2", :]]
+
+    transform.fit(train_df)
+    with pytest.raises(
+        NotImplementedError, match="This transform can't process segments that weren't present on train data"
+    ):
+        _ = transform.inverse_transform(test_df)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    (
+        MedianOutliersTransform(in_column="target"),
+        DensityOutliersTransform(in_column="target"),
+        PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel),
+    ),
+)
 def test_fit_transform_with_nans(transform, ts_diff_endings):
     ts_diff_endings.fit_transform([transform])
 


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Add validation of new segments like in `SklearnTransform`.

## Closing issues
Closes #1112.