### PR TITLE
[BUG] Can't get the forecast components from `CatBoostMultiSegmentModel`

### DIFF
--- a/etna/models/mixins.py
+++ b/etna/models/mixins.py
@@ -582,6 +582,7 @@ class MultiSegmentModelMixin(ModelForecastingMixin):
         # TODO: make it work with prediction intervals and context
         target_components_df = prediction_method(self=self._base_model, df=features_df, **kwargs)
         target_components_df["segment"] = segment_column
+        target_components_df["timestamp"] = features_df["timestamp"]
         target_components_df = TSDataset.to_dataset(target_components_df)
         return target_components_df
 

--- a/tests/test_models/common.py
+++ b/tests/test_models/common.py
@@ -1,4 +1,5 @@
 def _test_prediction_decomposition(model, train, test, prediction_size=None):
+    """Test that components are presented after in-sample and out-of-sample decomposition."""
     model.fit(train)
 
     predict_args = dict(ts=train, return_components=True)

--- a/tests/test_models/common.py
+++ b/tests/test_models/common.py
@@ -1,0 +1,15 @@
+def _test_prediction_decomposition(model, train, test, prediction_size=None):
+    model.fit(train)
+
+    predict_args = dict(ts=train, return_components=True)
+    forecast_args = dict(ts=test, return_components=True)
+
+    if prediction_size is not None:
+        predict_args["prediction_size"] = prediction_size
+        forecast_args["prediction_size"] = prediction_size
+
+    forecast = model.predict(**predict_args)
+    assert len(forecast.target_components_names) > 0
+
+    forecast = model.forecast(**forecast_args)
+    assert len(forecast.target_components_names) > 0

--- a/tests/test_models/test_autoarima_model.py
+++ b/tests/test_models/test_autoarima_model.py
@@ -5,8 +5,8 @@ from statsmodels.tsa.statespace.sarimax import SARIMAXResultsWrapper
 
 from etna.models import AutoARIMAModel
 from etna.pipeline import Pipeline
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 def _check_forecast(ts, model, horizon):

--- a/tests/test_models/test_autoarima_model.py
+++ b/tests/test_models/test_autoarima_model.py
@@ -6,6 +6,7 @@ from statsmodels.tsa.statespace.sarimax import SARIMAXResultsWrapper
 from etna.models import AutoARIMAModel
 from etna.pipeline import Pipeline
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 def _check_forecast(ts, model, horizon):
@@ -144,3 +145,8 @@ def test_forecast_1_point(example_tsds):
 def test_save_load(example_tsds):
     model = AutoARIMAModel()
     assert_model_equals_loaded_original(model=model, ts=example_tsds, transforms=[], horizon=3)
+
+
+def test_prediction_decomposition(outliers_tsds):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=AutoARIMAModel(), train=train, test=test)

--- a/tests/test_models/test_catboost.py
+++ b/tests/test_models/test_catboost.py
@@ -14,8 +14,8 @@ from etna.transforms import DateFlagsTransform
 from etna.transforms import LabelEncoderTransform
 from etna.transforms import OneHotEncoderTransform
 from etna.transforms.math import LagTransform
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 @pytest.mark.parametrize("catboostmodel", [CatBoostMultiSegmentModel, CatBoostPerSegmentModel])

--- a/tests/test_models/test_catboost.py
+++ b/tests/test_models/test_catboost.py
@@ -15,6 +15,7 @@ from etna.transforms import LabelEncoderTransform
 from etna.transforms import OneHotEncoderTransform
 from etna.transforms.math import LagTransform
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 @pytest.mark.parametrize("catboostmodel", [CatBoostMultiSegmentModel, CatBoostPerSegmentModel])
@@ -179,3 +180,9 @@ def test_decomposition_sums_to_target(dfs_w_exog):
 
     y_hat_pred = np.sum(components.values, axis=1)
     np.testing.assert_allclose(y_hat_pred, y_pred)
+
+
+@pytest.mark.parametrize("model", (CatBoostPerSegmentModel(), CatBoostMultiSegmentModel()))
+def test_prediction_decomposition(outliers_tsds, model):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=model, train=train, test=test)

--- a/tests/test_models/test_holt_winters_model.py
+++ b/tests/test_models/test_holt_winters_model.py
@@ -11,8 +11,8 @@ from etna.models import HoltWintersModel
 from etna.models import SimpleExpSmoothingModel
 from etna.models.holt_winters import _HoltWintersAdapter
 from etna.pipeline import Pipeline
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 @pytest.fixture

--- a/tests/test_models/test_holt_winters_model.py
+++ b/tests/test_models/test_holt_winters_model.py
@@ -12,6 +12,7 @@ from etna.models import SimpleExpSmoothingModel
 from etna.models.holt_winters import _HoltWintersAdapter
 from etna.pipeline import Pipeline
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 @pytest.fixture
@@ -251,3 +252,9 @@ def test_components_sum_up_to_target(
     pred = model.predict(pred_df)
 
     np.testing.assert_allclose(np.sum(components.values, axis=1), pred)
+
+
+@pytest.mark.parametrize("model", (SimpleExpSmoothingModel(), HoltModel(), HoltWintersModel()))
+def test_prediction_decomposition(outliers_tsds, model):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=model, train=train, test=test)

--- a/tests/test_models/test_linear_model.py
+++ b/tests/test_models/test_linear_model.py
@@ -17,6 +17,7 @@ from etna.pipeline import Pipeline
 from etna.transforms.math import LagTransform
 from etna.transforms.timestamp import DateFlagsTransform
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 @pytest.fixture
@@ -325,3 +326,9 @@ def test_linear_adapter_predict_components_sum_up_to_target(df_with_regressors, 
     target = adapter.predict(df)
     target_components = adapter.predict_components(df)
     np.testing.assert_array_almost_equal(target, target_components.sum(axis=1), decimal=10)
+
+
+@pytest.mark.parametrize("model", (LinearPerSegmentModel(), ElasticPerSegmentModel(), LinearMultiSegmentModel(), ElasticMultiSegmentModel()))
+def test_prediction_decomposition(example_reg_tsds, model):
+    train, test = example_reg_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=model, train=train, test=test)

--- a/tests/test_models/test_linear_model.py
+++ b/tests/test_models/test_linear_model.py
@@ -16,8 +16,8 @@ from etna.models.linear import _LinearAdapter
 from etna.pipeline import Pipeline
 from etna.transforms.math import LagTransform
 from etna.transforms.timestamp import DateFlagsTransform
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 @pytest.fixture
@@ -328,7 +328,9 @@ def test_linear_adapter_predict_components_sum_up_to_target(df_with_regressors, 
     np.testing.assert_array_almost_equal(target, target_components.sum(axis=1), decimal=10)
 
 
-@pytest.mark.parametrize("model", (LinearPerSegmentModel(), ElasticPerSegmentModel(), LinearMultiSegmentModel(), ElasticMultiSegmentModel()))
+@pytest.mark.parametrize(
+    "model", (LinearPerSegmentModel(), ElasticPerSegmentModel(), LinearMultiSegmentModel(), ElasticMultiSegmentModel())
+)
 def test_prediction_decomposition(example_reg_tsds, model):
     train, test = example_reg_tsds.train_test_split(test_size=10)
     _test_prediction_decomposition(model=model, train=train, test=test)

--- a/tests/test_models/test_prophet.py
+++ b/tests/test_models/test_prophet.py
@@ -8,8 +8,8 @@ from etna.datasets.tsdataset import TSDataset
 from etna.models import ProphetModel
 from etna.models.prophet import _ProphetAdapter
 from etna.pipeline import Pipeline
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 def test_run(new_format_df):

--- a/tests/test_models/test_prophet.py
+++ b/tests/test_models/test_prophet.py
@@ -9,6 +9,7 @@ from etna.models import ProphetModel
 from etna.models.prophet import _ProphetAdapter
 from etna.pipeline import Pipeline
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 def test_run(new_format_df):
@@ -364,3 +365,8 @@ def test_predict_components_sum_up_to_target(
     pred = model.predict(df=test, prediction_interval=False, quantiles=[])
 
     np.testing.assert_allclose(np.sum(components, axis=1), pred["target"].values)
+
+
+def test_prediction_decomposition(outliers_tsds):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=ProphetModel(), train=train, test=test)

--- a/tests/test_models/test_sarimax_model.py
+++ b/tests/test_models/test_sarimax_model.py
@@ -8,6 +8,7 @@ from etna.models import SARIMAXModel
 from etna.models.sarimax import _SARIMAXAdapter
 from etna.pipeline import Pipeline
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 def _check_forecast(ts, model, horizon):
@@ -236,3 +237,8 @@ def test_components_sum_up_to_target(
     components = components_method(df=pred_df)
 
     np.testing.assert_allclose(np.sum(components.values, axis=1), np.squeeze(pred))
+
+
+def test_prediction_decomposition(outliers_tsds):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=SARIMAXModel(), train=train, test=test)

--- a/tests/test_models/test_sarimax_model.py
+++ b/tests/test_models/test_sarimax_model.py
@@ -7,8 +7,8 @@ from statsmodels.tsa.statespace.sarimax import SARIMAXResultsWrapper
 from etna.models import SARIMAXModel
 from etna.models.sarimax import _SARIMAXAdapter
 from etna.pipeline import Pipeline
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 def _check_forecast(ts, model, horizon):

--- a/tests/test_models/test_simple_models.py
+++ b/tests/test_models/test_simple_models.py
@@ -12,6 +12,7 @@ from etna.models.naive import NaiveModel
 from etna.models.seasonal_ma import SeasonalMovingAverageModel
 from etna.pipeline import Pipeline
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 def _check_forecast(ts, model, horizon):
@@ -863,3 +864,9 @@ def test_deadline_ma_predict_components_correct(
 
     # testing out-of-sample prediction
     np.testing.assert_allclose(target_components_df.values[-1], out_of_sample_pred)
+
+
+@pytest.mark.parametrize("model", (MovingAverageModel(), NaiveModel()))
+def test_prediction_decomposition(example_tsds, model):
+    train, test = example_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=model, train=train, test=test, prediction_size=5)

--- a/tests/test_models/test_simple_models.py
+++ b/tests/test_models/test_simple_models.py
@@ -11,8 +11,8 @@ from etna.models.moving_average import MovingAverageModel
 from etna.models.naive import NaiveModel
 from etna.models.seasonal_ma import SeasonalMovingAverageModel
 from etna.pipeline import Pipeline
-from tests.test_models.utils import assert_model_equals_loaded_original
 from tests.test_models.common import _test_prediction_decomposition
+from tests.test_models.utils import assert_model_equals_loaded_original
 
 
 def _check_forecast(ts, model, horizon):

--- a/tests/test_models/test_tbats.py
+++ b/tests/test_models/test_tbats.py
@@ -12,9 +12,9 @@ from etna.models.tbats import TBATS
 from etna.models.tbats import BATSModel
 from etna.models.tbats import TBATSModel
 from etna.models.tbats import _TBATSAdapter
+from tests.test_models.common import _test_prediction_decomposition
 from tests.test_models.test_linear_model import linear_segments_by_parameters
 from tests.test_models.utils import assert_model_equals_loaded_original
-from tests.test_models.common import _test_prediction_decomposition
 
 
 @pytest.fixture()

--- a/tests/test_models/test_tbats.py
+++ b/tests/test_models/test_tbats.py
@@ -14,6 +14,7 @@ from etna.models.tbats import TBATSModel
 from etna.models.tbats import _TBATSAdapter
 from tests.test_models.test_linear_model import linear_segments_by_parameters
 from tests.test_models.utils import assert_model_equals_loaded_original
+from tests.test_models.common import _test_prediction_decomposition
 
 
 @pytest.fixture()
@@ -450,3 +451,9 @@ def test_predict_decompose_on_subset(periodic_dfs, estimator):
 
     y_hat_pred = np.sum(components.values, axis=1)
     np.testing.assert_allclose(y_hat_pred, np.squeeze(y_pred.values))
+
+
+@pytest.mark.parametrize("model", (BATSModel(), TBATSModel()))
+def test_prediction_decomposition(outliers_tsds, model):
+    train, test = outliers_tsds.train_test_split(test_size=10)
+    _test_prediction_decomposition(model=model, train=train, test=test)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [ ] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
<!-- Add a more detailed description of the changes if needed. 
No need for typos and docs improvements  -->

## Closing issues
<!-- Link Issue you are closing here. 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #1205 