### PR TITLE
Add default `params_to_tune` for `DateFlagsTransform`, `TimeFlagsTransform`, `SpecialDaysTransform`, `FourierTransform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default `params_to_tune` for `DeepARModel` and `TFTModel` ([#1210](https://github.com/tinkoff-ai/etna/pull/1210))
 - Add default `params_to_tune` for `HoltWintersModel`, `HoltModel` and `SimpleExpSmoothingModel` ([#1209](https://github.com/tinkoff-ai/etna/pull/1209))
 - Add default `params_to_tune` for `RNNModel` and `MLPModel` ([#1218](https://github.com/tinkoff-ai/etna/pull/1218))
+- Add default `params_to_tune` for `DateFlagsTransform`, `TimeFlagsTransform`, `SpecialDaysTransform` and `FourierTransform` ([#1228](https://github.com/tinkoff-ai/etna/pull/1228))
 ### Fixed
 - Fix bug in `GaleShapleyFeatureSelectionTransform` with wrong number of remaining features ([#1110](https://github.com/tinkoff-ai/etna/pull/1110))
 - `ProphetModel` fails with additional seasonality set ([#1157](https://github.com/tinkoff-ai/etna/pull/1157))

--- a/etna/transforms/timestamp/date_flags.py
+++ b/etna/transforms/timestamp/date_flags.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from math import ceil
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -7,8 +8,13 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
+from etna import SETTINGS
 from etna.transforms.base import FutureMixin
 from etna.transforms.base import IrreversibleTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class DateFlagsTransform(IrreversibleTransform, FutureMixin):
@@ -344,6 +350,28 @@ class DateFlagsTransform(IrreversibleTransform, FutureMixin):
         """Generate an array with the weekends flags."""
         weekend_days = (5, 6)
         return timestamp_series.apply(lambda x: x.weekday() in weekend_days).values
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        There are no restrictions on all ``False`` values for the flags.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "day_number_in_week": CategoricalDistribution([False, True]),
+            "day_number_in_month": CategoricalDistribution([False, True]),
+            "day_number_in_year": CategoricalDistribution([False, True]),
+            "week_number_in_month": CategoricalDistribution([False, True]),
+            "week_number_in_year": CategoricalDistribution([False, True]),
+            "month_number_in_year": CategoricalDistribution([False, True]),
+            "season_number": CategoricalDistribution([False, True]),
+            "year_number": CategoricalDistribution([False, True]),
+            "is_weekend": CategoricalDistribution([False, True]),
+        }
 
 
 __all__ = ["DateFlagsTransform"]

--- a/etna/transforms/timestamp/fourier.py
+++ b/etna/transforms/timestamp/fourier.py
@@ -13,7 +13,6 @@ from etna.transforms.base import IrreversibleTransform
 
 if SETTINGS.auto_required:
     from optuna.distributions import BaseDistribution
-    from optuna.distributions import CategoricalDistribution
     from optuna.distributions import IntLogUniformDistribution
 
 
@@ -164,14 +163,17 @@ class FourierTransform(IrreversibleTransform, FutureMixin):
     def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
         """Get default grid for tuning hyperparameters.
 
-        This grid sets ``mods`` parameter to ``None`` and tunes only ``order``.
+        * If the ``mods`` parameter is set, then the grid is empty.
 
-        This grid doesn't tune ``period`` parameter. It expected to be set by the user.
+        * If the ``order`` parameter is set, ``period`` parameter isn't tuned. It is expected to be set by the user.
 
         Returns
         -------
         :
             Grid to tune.
         """
+        if self.mods is not None:
+            return {}
+
         max_value = math.ceil(self.period / 2)
-        return {"order": IntLogUniformDistribution(low=1, high=max_value), "mods": CategoricalDistribution([None])}
+        return {"order": IntLogUniformDistribution(low=1, high=max_value)}

--- a/etna/transforms/timestamp/fourier.py
+++ b/etna/transforms/timestamp/fourier.py
@@ -1,4 +1,5 @@
 import math
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -6,8 +7,13 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
+from etna import SETTINGS
 from etna.transforms.base import FutureMixin
 from etna.transforms.base import IrreversibleTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import IntLogUniformDistribution
 
 
 class FourierTransform(IrreversibleTransform, FutureMixin):
@@ -150,3 +156,18 @@ class FourierTransform(IrreversibleTransform, FutureMixin):
             features[self._get_column_name(mod)] = np.sin(2 * np.pi * order * elapsed + np.pi / 2 * is_cos)
 
         return self._construct_answer(df, features)
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid doesn't tune ``period`` parameter. It expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        max_value = math.ceil(self.period / 2)
+        return {
+            "order": IntLogUniformDistribution(low=1, high=max_value),
+        }

--- a/etna/transforms/timestamp/special_days.py
+++ b/etna/transforms/timestamp/special_days.py
@@ -7,9 +7,14 @@ from typing import Tuple
 
 import pandas as pd
 
+from etna import SETTINGS
 from etna.transforms.base import FutureMixin
 from etna.transforms.base import IrreversiblePerSegmentWrapper
 from etna.transforms.base import OneSegmentTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 def calc_day_number_in_week(datetime_day: datetime.datetime) -> int:
@@ -215,6 +220,21 @@ class SpecialDaysTransform(IrreversiblePerSegmentWrapper, FutureMixin):
         if self.find_special_month_day:
             output_columns.append("anomaly_monthdays")
         return output_columns
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        There are no restrictions on all ``False`` values for the flags.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "find_special_weekday": CategoricalDistribution([False, True]),
+            "find_special_month_day": CategoricalDistribution([False, True]),
+        }
 
 
 __all__ = ["SpecialDaysTransform"]

--- a/etna/transforms/timestamp/time_flags.py
+++ b/etna/transforms/timestamp/time_flags.py
@@ -1,12 +1,18 @@
 from copy import deepcopy
+from typing import Dict
 from typing import List
 from typing import Optional
 
 import numpy as np
 import pandas as pd
 
+from etna import SETTINGS
 from etna.transforms.base import FutureMixin
 from etna.transforms.base import IrreversibleTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class TimeFlagsTransform(IrreversibleTransform, FutureMixin):
@@ -201,6 +207,25 @@ class TimeFlagsTransform(IrreversibleTransform, FutureMixin):
         Accepts a period length in hours as input and returns array where timestamps marked by period number.
         """
         return timestamp_series.apply(lambda x: x.hour // period_in_hours).values
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        There are no restrictions on all ``False`` values for the flags.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "minute_in_hour_number": CategoricalDistribution([False, True]),
+            "fifteen_minutes_in_hour_number": CategoricalDistribution([False, True]),
+            "hour_number": CategoricalDistribution([False, True]),
+            "half_hour_number": CategoricalDistribution([False, True]),
+            "half_day_number": CategoricalDistribution([False, True]),
+            "one_third_day_number": CategoricalDistribution([False, True]),
+        }
 
 
 __all__ = ["TimeFlagsTransform"]

--- a/tests/test_pipeline/test_autoregressive_pipeline.py
+++ b/tests/test_pipeline/test_autoregressive_pipeline.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
+from optuna.distributions import CategoricalDistribution
 from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 
@@ -394,6 +395,15 @@ def test_predict_return_components(example_tsds, model_fixture, request):
                 "model.depth": IntUniformDistribution(low=1, high=11, step=1),
                 "model.l2_leaf_reg": LogUniformDistribution(low=0.1, high=200.0),
                 "model.random_strength": LogUniformDistribution(low=1e-05, high=10.0),
+                "transforms.0.day_number_in_week": CategoricalDistribution([False, True]),
+                "transforms.0.day_number_in_month": CategoricalDistribution([False, True]),
+                "transforms.0.day_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.week_number_in_month": CategoricalDistribution([False, True]),
+                "transforms.0.week_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.month_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.season_number": CategoricalDistribution([False, True]),
+                "transforms.0.year_number": CategoricalDistribution([False, True]),
+                "transforms.0.is_weekend": CategoricalDistribution([False, True]),
             },
         ),
     ],

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
+from optuna.distributions import CategoricalDistribution
 from optuna.distributions import IntUniformDistribution
 from optuna.distributions import LogUniformDistribution
 
@@ -1221,6 +1222,15 @@ def test_predict_return_components(
                 "model.depth": IntUniformDistribution(low=1, high=11, step=1),
                 "model.l2_leaf_reg": LogUniformDistribution(low=0.1, high=200.0),
                 "model.random_strength": LogUniformDistribution(low=1e-05, high=10.0),
+                "transforms.0.day_number_in_week": CategoricalDistribution([False, True]),
+                "transforms.0.day_number_in_month": CategoricalDistribution([False, True]),
+                "transforms.0.day_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.week_number_in_month": CategoricalDistribution([False, True]),
+                "transforms.0.week_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.month_number_in_year": CategoricalDistribution([False, True]),
+                "transforms.0.season_number": CategoricalDistribution([False, True]),
+                "transforms.0.year_number": CategoricalDistribution([False, True]),
+                "transforms.0.is_weekend": CategoricalDistribution([False, True]),
             },
         ),
     ],

--- a/tests/test_transforms/test_timestamp/test_dateflags_transform.py
+++ b/tests/test_transforms/test_timestamp/test_dateflags_transform.py
@@ -11,6 +11,7 @@ import pytest
 
 from etna.datasets import TSDataset
 from etna.transforms.timestamp import DateFlagsTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 WEEKEND_DAYS = (5, 6)
@@ -289,3 +290,10 @@ def test_save_load(train_ts):
     ts = train_ts
     transform = DateFlagsTransform()
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+def test_params_to_tune(train_ts):
+    transform = DateFlagsTransform()
+    ts = train_ts
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_timestamp/test_fourier_transform.py
+++ b/tests/test_transforms/test_timestamp/test_fourier_transform.py
@@ -8,6 +8,7 @@ from etna.datasets import TSDataset
 from etna.metrics import R2
 from etna.models import LinearPerSegmentModel
 from etna.transforms.timestamp import FourierTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -166,3 +167,18 @@ def test_forecast(ts_trend_seasonal):
 def test_save_load(ts_trend_seasonal):
     transform = FourierTransform(period=7, order=3)
     assert_transformation_equals_loaded_original(transform=transform, ts=ts_trend_seasonal)
+
+
+# TODO: fix this
+@pytest.mark.parametrize(
+    "transform",
+    [
+        FourierTransform(period=7, order=1),
+        FourierTransform(period=30.4, order=1),
+        FourierTransform(period=365.25, order=1),
+    ],
+)
+def test_params_to_tune(transform, ts_trend_seasonal):
+    ts = ts_trend_seasonal
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_timestamp/test_fourier_transform.py
+++ b/tests/test_transforms/test_timestamp/test_fourier_transform.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 import pytest
+from optuna.samplers import RandomSampler
 
 from etna.datasets import TSDataset
 from etna.metrics import R2
@@ -181,3 +182,30 @@ def test_params_to_tune(transform, ts_trend_seasonal):
     ts = ts_trend_seasonal
     assert len(transform.params_to_tune()) > 0
     assert_sampling_is_valid(transform=transform, ts=ts)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        FourierTransform(period=7, mods=[1]),
+        FourierTransform(period=7, mods=[1, 4]),
+    ],
+)
+def test_params_to_tune_with_mods(transform, ts_trend_seasonal):
+    """Test that params_to_tune works with mods.
+
+    Setting parameters one by one isn't possible for mods. This case should check setting all parameters in one step.
+    """
+    ts = ts_trend_seasonal
+    grid = transform.params_to_tune()
+    assert len(grid) > 0
+    sampler = RandomSampler(seed=0)
+
+    params_to_set = {}
+    for name, distribution in grid.items():
+        value = sampler.sample_independent(study=None, trial=None, param_name=name, param_distribution=distribution)
+        params_to_set[name] = value
+
+    new_transform = transform.set_params(**params_to_set)
+    assert new_transform.mods is None
+    new_transform.fit(ts)

--- a/tests/test_transforms/test_timestamp/test_fourier_transform.py
+++ b/tests/test_transforms/test_timestamp/test_fourier_transform.py
@@ -50,15 +50,15 @@ def ts_trend_seasonal(random_seed) -> TSDataset:
     return TSDataset(TSDataset.to_dataset(classic_df), freq="D")
 
 
-@pytest.mark.parametrize("order, mods, repr_mods", [(None, [1, 2, 3, 4], [1, 2, 3, 4]), (2, None, [1, 2, 3, 4])])
-def test_repr(order, mods, repr_mods):
+@pytest.mark.parametrize("order, mods", [(None, [1, 2, 3, 4]), (2, None)])
+def test_repr(order, mods):
     transform = FourierTransform(
         period=10,
         order=order,
         mods=mods,
     )
     transform_repr = transform.__repr__()
-    true_repr = f"FourierTransform(period = 10, order = None, mods = {repr_mods}, out_column = None, )"
+    true_repr = f"FourierTransform(period = 10, order = {order}, mods = {mods}, out_column = None, )"
     assert transform_repr == true_repr
 
 
@@ -169,7 +169,6 @@ def test_save_load(ts_trend_seasonal):
     assert_transformation_equals_loaded_original(transform=transform, ts=ts_trend_seasonal)
 
 
-# TODO: fix this
 @pytest.mark.parametrize(
     "transform",
     [

--- a/tests/test_transforms/test_timestamp/test_holiday_transform.py
+++ b/tests/test_transforms/test_timestamp/test_holiday_transform.py
@@ -191,3 +191,8 @@ def test_holidays_out_column_added_to_regressors(example_tsds, expected_regresso
 def test_save_load(example_tsds):
     transform = HolidayTransform()
     assert_transformation_equals_loaded_original(transform=transform, ts=example_tsds)
+
+
+def test_params_to_tune():
+    transform = HolidayTransform()
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_timestamp/test_special_days_transform.py
+++ b/tests/test_transforms/test_timestamp/test_special_days_transform.py
@@ -6,6 +6,7 @@ import pytest
 from etna.datasets import TSDataset
 from etna.transforms.timestamp import SpecialDaysTransform
 from etna.transforms.timestamp.special_days import _OneSegmentSpecialDaysTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -200,3 +201,10 @@ def test_save_load(df_with_specials):
     ts = TSDataset(df=TSDataset.to_dataset(df), freq="D")
     transform = SpecialDaysTransform()
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+def test_params_to_tune(train_ts):
+    transform = SpecialDaysTransform()
+    ts = train_ts
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_timestamp/test_special_days_transform.py
+++ b/tests/test_transforms/test_timestamp/test_special_days_transform.py
@@ -49,6 +49,16 @@ def df_with_specials():
 
 
 @pytest.fixture()
+def ts_with_specials(df_with_specials):
+    """Create dataset with special weekdays and monthdays."""
+    df = df_with_specials.reset_index()
+    df["segment"] = "1"
+    df = df[["timestamp", "segment", "target"]]
+    ts = TSDataset(df=TSDataset.to_dataset(df), freq="D")
+    return ts
+
+
+@pytest.fixture()
 def constant_days_two_segments_ts(constant_days_df: pd.DataFrame):
     """Create TSDataset that has two segments with constant columns each."""
     df_1 = constant_days_df.reset_index()
@@ -194,17 +204,14 @@ def test_fit_transform_with_nans(ts_diff_endings):
     transform.fit_transform(ts_diff_endings)
 
 
-def test_save_load(df_with_specials):
-    df = df_with_specials.reset_index()
-    df["segment"] = "1"
-    df = df[["timestamp", "segment", "target"]]
-    ts = TSDataset(df=TSDataset.to_dataset(df), freq="D")
+def test_save_load(ts_with_specials):
+    ts = ts_with_specials
     transform = SpecialDaysTransform()
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
 
 
-def test_params_to_tune(train_ts):
+def test_params_to_tune(ts_with_specials):
     transform = SpecialDaysTransform()
-    ts = train_ts
+    ts = ts_with_specials
     assert len(transform.params_to_tune()) > 0
     assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_timestamp/test_timeflags_transform.py
+++ b/tests/test_transforms/test_timestamp/test_timeflags_transform.py
@@ -10,6 +10,7 @@ import pytest
 
 from etna.datasets import TSDataset
 from etna.transforms.timestamp import TimeFlagsTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 INIT_PARAMS_TEMPLATE = {
@@ -223,3 +224,10 @@ def test_save_load(train_ts):
     ts = train_ts
     transform = TimeFlagsTransform()
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+def test_params_to_tune(train_ts):
+    transform = TimeFlagsTransform()
+    ts = train_ts
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look at #1221.

## Closing issues
Closes #1221.