### PR TITLE
Fix `BaseReconciliator` to work on pandas==1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 ### Fixed
 -
--
+- Fix `BaseReconciliator` to work on `pandas==1.1.5` ([#1229](https://github.com/tinkoff-ai/etna/pull/1229))
 -
 -
 

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -812,10 +812,18 @@ class TSDataset:
         -------
         :
             Dataframe in wide format and optionally hierarchical structure
+
+        Raises
+        ------
+        ValueError
+            If ``level_columns`` is empty
         """
+        if len(level_columns) == 0:
+            raise ValueError("Value of level_columns shouldn't be empty!")
+
         df_copy = df.copy(deep=True)
         df_copy["segment"] = df_copy[level_columns].astype("string").agg(sep.join, axis=1)
-        if not keep_level_columns and len(level_columns) > 0:
+        if not keep_level_columns:
             df_copy.drop(columns=level_columns, inplace=True)
         df_copy = TSDataset.to_dataset(df_copy)
 

--- a/etna/datasets/tsdataset.py
+++ b/etna/datasets/tsdataset.py
@@ -815,7 +815,7 @@ class TSDataset:
         """
         df_copy = df.copy(deep=True)
         df_copy["segment"] = df_copy[level_columns].astype("string").agg(sep.join, axis=1)
-        if not keep_level_columns:
+        if not keep_level_columns and len(level_columns) > 0:
             df_copy.drop(columns=level_columns, inplace=True)
         df_copy = TSDataset.to_dataset(df_copy)
 

--- a/etna/reconciliation/base.py
+++ b/etna/reconciliation/base.py
@@ -94,7 +94,8 @@ class BaseReconciliator(ABC, BaseMixin):
         )
 
         target_components_df = df_reconciled.loc[:, pd.IndexSlice[:, ts.target_components_names]]
-        df_reconciled = df_reconciled.drop(columns=list(ts.target_components_names), level="feature")
+        if len(ts.target_components_names) > 0:  # for pandas >=1.1, <1.2
+            df_reconciled = df_reconciled.drop(columns=list(ts.target_components_names), level="feature")
 
         ts_reconciled = TSDataset(
             df=df_reconciled,

--- a/tests/test_datasets/test_hierarchical_dataset.py
+++ b/tests/test_datasets/test_hierarchical_dataset.py
@@ -307,6 +307,12 @@ def test_level_names_without_hierarchical_structure(market_level_df):
     assert ts_level_names is None
 
 
+def test_to_hierarchical_dataset_fails_empty_level_columns(product_level_df_long):
+    df = product_level_df_long
+    with pytest.raises(ValueError, match="Value of level_columns shouldn't be empty"):
+        _ = TSDataset.to_hierarchical_dataset(df=df, level_columns=[])
+
+
 def test_to_hierarchical_dataset_not_change_input_df(product_level_df_long):
     df = product_level_df_long
     df_before = df.copy()


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Add check on length before running `DataFrame.drop`.

## Closing issues
Closes #1212.
