### PR TITLE
Add default `params_to_tune` for math transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default `params_to_tune` for `HoltWintersModel`, `HoltModel` and `SimpleExpSmoothingModel` ([#1209](https://github.com/tinkoff-ai/etna/pull/1209))
 - Add default `params_to_tune` for `RNNModel` and `MLPModel` ([#1218](https://github.com/tinkoff-ai/etna/pull/1218))
 - Add default `params_to_tune` for `DateFlagsTransform`, `TimeFlagsTransform`, `SpecialDaysTransform` and `FourierTransform` ([#1228](https://github.com/tinkoff-ai/etna/pull/1228))
+- Add default `params_to_tune` for `DifferencingTransform`, `MedianTransform`, `MaxTransform`, `MinTransform`, `QuantileTransform`, `StdTransform`, `MeanTransform`, `MADTransform`, `MinMaxDifferenceTransform`, `SumTransform`, `BoxCoxTransform`, `YeoJohnsonTransform`, `MaxAbsScalerTransform`, `MinMaxScalerTransform`, `RobustScalerTransform` and `StandardScalerTransform` ([#1233](https://github.com/tinkoff-ai/etna/pull/1233))
 ### Fixed
 - Fix bug in `GaleShapleyFeatureSelectionTransform` with wrong number of remaining features ([#1110](https://github.com/tinkoff-ai/etna/pull/1110))
 - `ProphetModel` fails with additional seasonality set ([#1157](https://github.com/tinkoff-ai/etna/pull/1157))

--- a/etna/transforms/math/differencing.py
+++ b/etna/transforms/math/differencing.py
@@ -8,10 +8,15 @@ from typing import cast
 import numpy as np
 import pandas as pd
 
+from etna import SETTINGS
 from etna.datasets import TSDataset
 from etna.transforms.base import ReversibleTransform
 from etna.transforms.utils import check_new_segments
 from etna.transforms.utils import match_target_quantiles
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import IntUniformDistribution
 
 
 class _SingleDifferencingTransform(ReversibleTransform):
@@ -473,3 +478,17 @@ class DifferencingTransform(ReversibleTransform):
         for transform in self._differencing_transforms[::-1]:
             result_df = transform._inverse_transform(result_df)
         return result_df
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes only ``order`` parameter. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "order": IntUniformDistribution(low=1, high=2),
+        }

--- a/etna/transforms/math/power.py
+++ b/etna/transforms/math/power.py
@@ -1,11 +1,17 @@
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
 
 from sklearn.preprocessing import PowerTransformer
 
+from etna import SETTINGS
 from etna.transforms.math.sklearn import SklearnTransform
 from etna.transforms.math.sklearn import TransformMode
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class YeoJohnsonTransform(SklearnTransform):
@@ -58,6 +64,24 @@ class YeoJohnsonTransform(SklearnTransform):
             mode=mode,
         )
 
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``mode``, ``standardize``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "standardize": CategoricalDistribution([False, True]),
+            }
+        )
+        return grid
+
 
 class BoxCoxTransform(SklearnTransform):
     """BoxCoxTransform applies Box-Cox transformation to DataFrame.
@@ -108,6 +132,24 @@ class BoxCoxTransform(SklearnTransform):
             transformer=PowerTransformer(method="box-cox", standardize=self.standardize),
             mode=mode,
         )
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``mode``, ``standardize``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "standardize": CategoricalDistribution([False, True]),
+            }
+        )
+        return grid
 
 
 __all__ = ["BoxCoxTransform", "YeoJohnsonTransform"]

--- a/etna/transforms/math/scalers.py
+++ b/etna/transforms/math/scalers.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -8,8 +9,13 @@ from sklearn.preprocessing import MinMaxScaler
 from sklearn.preprocessing import RobustScaler
 from sklearn.preprocessing import StandardScaler
 
+from etna import SETTINGS
 from etna.transforms.math.sklearn import SklearnTransform
 from etna.transforms.math.sklearn import TransformMode
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class StandardScalerTransform(SklearnTransform):
@@ -68,6 +74,26 @@ class StandardScalerTransform(SklearnTransform):
             inplace=inplace,
             mode=mode,
         )
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``mode``, ``with_mean``, ``with_std``.
+        Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "with_mean": CategoricalDistribution([False, True]),
+                "with_std": CategoricalDistribution([False, True]),
+            }
+        )
+        return grid
 
 
 class RobustScalerTransform(SklearnTransform):
@@ -145,6 +171,27 @@ class RobustScalerTransform(SklearnTransform):
             mode=mode,
         )
 
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``mode``, ``with_centering``, ``with_scaling``, ``unit_variance``.
+        Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "with_centering": CategoricalDistribution([False, True]),
+                "with_scaling": CategoricalDistribution([False, True]),
+                "unit_variance": CategoricalDistribution([False, True]),
+            }
+        )
+        return grid
+
 
 class MinMaxScalerTransform(SklearnTransform):
     """Transform features by scaling each feature to a given range.
@@ -202,6 +249,24 @@ class MinMaxScalerTransform(SklearnTransform):
             transformer=MinMaxScaler(feature_range=self.feature_range, clip=self.clip, copy=True),
             mode=mode,
         )
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``mode``, ``clip``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "clip": CategoricalDistribution([False, True]),
+            }
+        )
+        return grid
 
 
 class MaxAbsScalerTransform(SklearnTransform):

--- a/etna/transforms/math/sklearn.py
+++ b/etna/transforms/math/sklearn.py
@@ -10,12 +10,17 @@ import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin
 
+from etna import SETTINGS
 from etna.core import StringEnumWithRepr
 from etna.datasets import TSDataset
 from etna.datasets import set_columns_wide
 from etna.transforms.base import ReversibleTransform
 from etna.transforms.utils import check_new_segments
 from etna.transforms.utils import match_target_quantiles
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class TransformMode(StringEnumWithRepr):
@@ -298,3 +303,17 @@ class SklearnTransform(ReversibleTransform):
         if self.inplace:
             return []
         return self.out_column_regressors
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes only ``mode`` parameter. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "mode": CategoricalDistribution(["per-segment", "macro"]),
+        }

--- a/etna/transforms/math/statistics.py
+++ b/etna/transforms/math/statistics.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -7,8 +8,14 @@ import bottleneck as bn
 import numpy as np
 import pandas as pd
 
+from etna import SETTINGS
 from etna.datasets import TSDataset
 from etna.transforms.base import IrreversibleTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import IntUniformDistribution
+    from optuna.distributions import UniformDistribution
 
 
 class WindowStatisticsTransform(IrreversibleTransform, ABC):
@@ -112,6 +119,20 @@ class WindowStatisticsTransform(IrreversibleTransform, ABC):
             raise ValueError("Fit the transform to get the correct regressors info!")
         return [self.out_column_name] if self.in_column_regressor else []
 
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes only ``window`` parameter. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "window": IntUniformDistribution(low=1, high=20),
+        }
+
 
 class MeanTransform(WindowStatisticsTransform):
     """MeanTransform computes average value for given window.
@@ -192,6 +213,24 @@ class MeanTransform(WindowStatisticsTransform):
             # Loop prevents from memory overflow, 3d tensor is materialized after multiplication
             mean[:, segment] = bn.nanmean(series[:, segment] * self._alpha_range, axis=1)
         return mean
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``window``, ``alpha``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "alpha": UniformDistribution(low=0.2, high=1),
+            }
+        )
+        return grid
 
 
 class StdTransform(WindowStatisticsTransform):
@@ -308,6 +347,24 @@ class QuantileTransform(WindowStatisticsTransform):
         # There is no "nanquantile" in bottleneck, "apply_along_axis" can't be replace with "axis=2"
         series = np.apply_along_axis(np.nanquantile, axis=2, arr=series, q=self.quantile)
         return series
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``window``, ``quantile``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        grid = super().params_to_tune()
+        grid.update(
+            {
+                "quantile": UniformDistribution(low=0, high=1),
+            }
+        )
+        return grid
 
 
 class MinTransform(WindowStatisticsTransform):

--- a/tests/test_transforms/test_math/test_add_constant_transform.py
+++ b/tests/test_transforms/test_math/test_add_constant_transform.py
@@ -86,3 +86,8 @@ def test_get_regressors_info_not_fitted():
     transform = AddConstTransform(in_column="target", value=1, out_column="out_column")
     with pytest.raises(ValueError, match="Fit the transform to get the correct regressors info!"):
         _ = transform.get_regressors_info()
+
+
+def test_params_to_tune():
+    transform = AddConstTransform(in_column="target", value=1)
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_math/test_differencing_transform.py
+++ b/tests/test_transforms/test_math/test_differencing_transform.py
@@ -15,6 +15,7 @@ from etna.pipeline import Pipeline
 from etna.transforms import LagTransform
 from etna.transforms.math import DifferencingTransform
 from etna.transforms.math.differencing import _SingleDifferencingTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 from tests.utils import select_segments_subset
 
@@ -594,3 +595,10 @@ def test_get_regressors_info_not_fitted():
     transform = DifferencingTransform(in_column="target")
     with pytest.raises(ValueError, match="Fit the transform to get the correct regressors info!"):
         _ = transform.get_regressors_info()
+
+
+@pytest.mark.parametrize("transform", [DifferencingTransform(in_column="target")])
+def test_params_to_tune(transform, ts_nans):
+    ts = ts_nans
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_math/test_lag_transform.py
+++ b/tests/test_transforms/test_math/test_lag_transform.py
@@ -128,3 +128,8 @@ def test_save_load(int_ts_two_segments):
     ts = int_ts_two_segments
     transform = LagTransform(in_column="target", lags=10)
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+def test_params_to_tune():
+    transform = LagTransform(in_column="target", lags=10)
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_math/test_lambda_transform.py
+++ b/tests/test_transforms/test_math/test_lambda_transform.py
@@ -164,3 +164,8 @@ def test_get_regressors_info_not_fitted():
     transform = LambdaTransform(in_column="target", inplace=False, transform_func=lambda x: x)
     with pytest.raises(ValueError, match="Fit the transform to get the correct regressors info!"):
         _ = transform.get_regressors_info()
+
+
+def test_params_to_tune():
+    transform = LambdaTransform(in_column="target", inplace=False, transform_func=lambda x: x)
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_math/test_log_transform.py
+++ b/tests/test_transforms/test_math/test_log_transform.py
@@ -124,3 +124,8 @@ def test_get_regressors_info_not_fitted():
     transform = LogTransform(in_column="target")
     with pytest.raises(ValueError, match="Fit the transform to get the correct regressors info!"):
         _ = transform.get_regressors_info()
+
+
+def test_params_to_tune():
+    transform = LogTransform(in_column="target")
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_math/test_power_transform.py
+++ b/tests/test_transforms/test_math/test_power_transform.py
@@ -11,6 +11,7 @@ from etna.datasets import TSDataset
 from etna.transforms import AddConstTransform
 from etna.transforms.math import BoxCoxTransform
 from etna.transforms.math import YeoJohnsonTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -128,3 +129,12 @@ def test_save_load(transform_constructor, mode, positive_ts):
     ts = positive_ts
     transform = transform_constructor(in_column="target", mode=mode)
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+@pytest.mark.parametrize("transform_constructor", (BoxCoxTransform, YeoJohnsonTransform))
+@pytest.mark.parametrize("mode", ("macro", "per-segment"))
+def test_params_to_tune(transform_constructor, mode, positive_ts):
+    ts = positive_ts
+    transform = transform_constructor(in_column="target", mode=mode)
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_math/test_power_transform.py
+++ b/tests/test_transforms/test_math/test_power_transform.py
@@ -131,10 +131,10 @@ def test_save_load(transform_constructor, mode, positive_ts):
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
 
 
-@pytest.mark.parametrize("transform_constructor", (BoxCoxTransform, YeoJohnsonTransform))
+@pytest.mark.parametrize("transform_constructor, expected_length", [(BoxCoxTransform, 2), (YeoJohnsonTransform, 2)])
 @pytest.mark.parametrize("mode", ("macro", "per-segment"))
-def test_params_to_tune(transform_constructor, mode, positive_ts):
+def test_params_to_tune(transform_constructor, expected_length, mode, positive_ts):
     ts = positive_ts
     transform = transform_constructor(in_column="target", mode=mode)
-    assert len(transform.params_to_tune()) > 0
+    assert len(transform.params_to_tune()) == expected_length
     assert_sampling_is_valid(transform=transform, ts=ts)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #1226.

## Closing issues
Closes #1226.
