### PR TITLE
Add default `params_to_tune` for decomposition transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default `params_to_tune` for `MedianOutliersTransform`, `DensityOutliersTransform` and `PredictionIntervalOutliersTransform` ([#1231](https://github.com/tinkoff-ai/etna/pull/1231))
 - Add default `params_to_tune` for `TimeSeriesImputerTransform` ([#1232](https://github.com/tinkoff-ai/etna/pull/1232))
 - Add default `params_to_tune` for `DifferencingTransform`, `MedianTransform`, `MaxTransform`, `MinTransform`, `QuantileTransform`, `StdTransform`, `MeanTransform`, `MADTransform`, `MinMaxDifferenceTransform`, `SumTransform`, `BoxCoxTransform`, `YeoJohnsonTransform`, `MaxAbsScalerTransform`, `MinMaxScalerTransform`, `RobustScalerTransform` and `StandardScalerTransform` ([#1233](https://github.com/tinkoff-ai/etna/pull/1233))
+- Add default `params_to_tune` for `ChangePointsSegmentationTransform`, `ChangePointsTrendTransform`, `ChangePointsLevelTransform`, `TrendTransform`, `LinearTrendTransform`, `TheilSenTrendTransform` and `STLTransform` ([#1243](https://github.com/tinkoff-ai/etna/pull/1243))
 ### Fixed
 - Fix bug in `GaleShapleyFeatureSelectionTransform` with wrong number of remaining features ([#1110](https://github.com/tinkoff-ai/etna/pull/1110))
 - `ProphetModel` fails with additional seasonality set ([#1157](https://github.com/tinkoff-ai/etna/pull/1157))

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ ETNA documentation is available [here](https://etna-docs.netlify.app/).
 
 ## Community
 
-To ask the questions or discuss the library you can join our [telegram chat](t.me/etna_support). 
+To ask the questions or discuss the library you can join our [telegram chat](https://t.me/etna_support). 
 [Discussions section](https://github.com/tinkoff-ai/etna/discussions) on github is also open for this purpose.
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ ETNA documentation is available [here](https://etna-docs.netlify.app/).
 
 ## Community
 
-To ask the questions or discuss the library you can join our [telegram chat](https://t.me/etna_support). 
+To ask the questions or discuss the library you can join our [telegram chat](t.me/etna_support). 
 [Discussions section](https://github.com/tinkoff-ai/etna/discussions) on github is also open for this purpose.
 
 ## Resources

--- a/etna/transforms/decomposition/change_points_based/level.py
+++ b/etna/transforms/decomposition/change_points_based/level.py
@@ -60,6 +60,12 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
     it uses information from the whole train part.
     """
 
+    _default_change_points_model = RupturesChangePointsModel(
+        change_points_model=Binseg(model="ar"),
+        n_bkps=5,
+    )
+    _default_per_interval_model = MeanPerIntervalModel()
+
     def __init__(
         self,
         in_column: str,
@@ -74,23 +80,19 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
             name of column to apply transform to
         change_points_model:
             model to get trend change points,
-            by default :py:class:`ruptures.detection.Binseg` model is used
+            by default :py:class:`ruptures.detection.Binseg` in a wrapper with ``n_bkps=5`` is used
         per_interval_model:
             model to process intervals of segment,
             by default mean value is used to evaluate the interval
         """
         self.in_column = in_column
 
-        self._is_change_points_model_default = change_points_model is None
         self.change_points_model = (
-            change_points_model
-            if change_points_model is not None
-            else RupturesChangePointsModel(
-                change_points_model=Binseg(model="l2"),
-                n_bkps=5,
-            )
+            change_points_model if change_points_model is not None else self._default_change_points_model
         )
-        self.per_interval_model = per_interval_model if per_interval_model is not None else MeanPerIntervalModel()
+        self.per_interval_model = (
+            per_interval_model if per_interval_model is not None else self._default_per_interval_model
+        )
 
         super().__init__(
             transform=_OneSegmentChangePointsLevelTransform(
@@ -101,10 +103,15 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
             required_features=[in_column],
         )
 
+    @property
+    def _is_change_points_model_default(self) -> bool:
+        # it can't see the difference between Binseg(model="ar") and Binseg(model="l1")
+        return self.change_points_model.to_dict() == self._default_change_points_model.to_dict()
+
     def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
         """Get default grid for tuning hyperparameters.
 
-        If ``change_points_model`` isn't set then this grid tunes parameters:
+        If ``change_points_model`` is equal to default then this grid tunes parameters:
         ``change_points_model.change_points_model.model``, ``change_points_model.n_bkps``.
         Other parameters are expected to be set by the user.
 

--- a/etna/transforms/decomposition/change_points_based/level.py
+++ b/etna/transforms/decomposition/change_points_based/level.py
@@ -1,7 +1,9 @@
+from typing import Dict
 from typing import Optional
 
 from ruptures import Binseg
 
+from etna import SETTINGS
 from etna.transforms.decomposition.change_points_based.base import BaseChangePointsModelAdapter
 from etna.transforms.decomposition.change_points_based.base import ReversibleChangePointsTransform
 from etna.transforms.decomposition.change_points_based.change_points_models.ruptures_based import (
@@ -10,6 +12,11 @@ from etna.transforms.decomposition.change_points_based.change_points_models.rupt
 from etna.transforms.decomposition.change_points_based.detrend import _OneSegmentChangePointsTrendTransform
 from etna.transforms.decomposition.change_points_based.per_interval_models import MeanPerIntervalModel
 from etna.transforms.decomposition.change_points_based.per_interval_models import StatisticsPerIntervalModel
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
+    from optuna.distributions import IntUniformDistribution
 
 
 class _OneSegmentChangePointsLevelTransform(_OneSegmentChangePointsTrendTransform):
@@ -36,7 +43,16 @@ class _OneSegmentChangePointsLevelTransform(_OneSegmentChangePointsTrendTransfor
 
 
 class ChangePointsLevelTransform(ReversibleChangePointsTransform):
-    """ChangePointsLevelTransform uses :py:class:`ruptures.detection.Binseg` model as a change point detection model.
+    """Transform that makes a detrending of change-point intervals.
+
+    This class differs from :py:class:`~etna.transforms.decomposition.change_points_based.detrend.ChangePointsTrendTransform`
+    only by default values for ``change_points_model`` and ``per_interval_model``.
+
+    Transform divides each segment into intervals using ``change_points_model``.
+    Then a separate model is fitted on each interval using ``per_interval_model``.
+    Values predicted by the model are subtracted from each interval.
+
+    Evaluated function can be linear, mean, median, etc. Look at the signature to find out which models can be used.
 
     Warning
     -------
@@ -57,11 +73,15 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
         in_column:
             name of column to apply transform to
         change_points_model:
-            model to get trend change points
+            model to get trend change points,
+            by default :py:class:`ruptures.detection.Binseg` model is used
         per_interval_model:
-            model to process intervals of segment
+            model to process intervals of segment,
+            by default mean value is used to evaluate the interval
         """
         self.in_column = in_column
+
+        self._is_change_points_model_default = change_points_model is None
         self.change_points_model = (
             change_points_model
             if change_points_model is not None
@@ -71,6 +91,7 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
             )
         )
         self.per_interval_model = per_interval_model if per_interval_model is not None else MeanPerIntervalModel()
+
         super().__init__(
             transform=_OneSegmentChangePointsLevelTransform(
                 in_column=self.in_column,
@@ -79,3 +100,25 @@ class ChangePointsLevelTransform(ReversibleChangePointsTransform):
             ),
             required_features=[in_column],
         )
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        If ``change_points_model`` isn't set then this grid tunes parameters:
+        ``change_points_model.change_points_model.model``, ``change_points_model.n_bkps``.
+        Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        if self._is_change_points_model_default:
+            return {
+                "change_points_model.change_points_model.model": CategoricalDistribution(
+                    ["l1", "l2", "normal", "rbf", "cosine", "linear", "clinear", "ar", "mahalanobis", "rank"]
+                ),
+                "change_points_model.n_bkps": IntUniformDistribution(low=5, high=30),
+            }
+        else:
+            return {}

--- a/etna/transforms/decomposition/change_points_based/per_interval_models/base.py
+++ b/etna/transforms/decomposition/change_points_based/per_interval_models/base.py
@@ -10,7 +10,7 @@ class PerIntervalModel(BaseMixin, ABC):
     """Class to handle intervals in change point based transforms.
 
     PerIntervalModel is a class to process intervals between change points
-    in :py:module:`~etna.transforms.decomposition.change_points_based` transforms.
+    in :py:mod:`~etna.transforms.decomposition.change_points_based` transforms.
     """
 
     @abstractmethod

--- a/etna/transforms/decomposition/change_points_based/per_interval_models/base.py
+++ b/etna/transforms/decomposition/change_points_based/per_interval_models/base.py
@@ -10,7 +10,7 @@ class PerIntervalModel(BaseMixin, ABC):
     """Class to handle intervals in change point based transforms.
 
     PerIntervalModel is a class to process intervals between change points
-    in `~etna.transforms.decomposition.change_points_based` transforms.
+    in :py:module:`~etna.transforms.decomposition.change_points_based` transforms.
     """
 
     @abstractmethod

--- a/etna/transforms/decomposition/change_points_based/trend.py
+++ b/etna/transforms/decomposition/change_points_based/trend.py
@@ -1,12 +1,23 @@
+from typing import Dict
 from typing import Optional
 
 import pandas as pd
+from ruptures import Binseg
 
+from etna import SETTINGS
 from etna.transforms.decomposition.change_points_based.base import IrreversibleChangePointsTransform
 from etna.transforms.decomposition.change_points_based.change_points_models import BaseChangePointsModelAdapter
+from etna.transforms.decomposition.change_points_based.change_points_models.ruptures_based import (
+    RupturesChangePointsModel,
+)
 from etna.transforms.decomposition.change_points_based.detrend import _OneSegmentChangePointsTrendTransform
 from etna.transforms.decomposition.change_points_based.per_interval_models import PerIntervalModel
 from etna.transforms.decomposition.change_points_based.per_interval_models import SklearnRegressionPerIntervalModel
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
+    from optuna.distributions import IntUniformDistribution
 
 
 class _OneSegmentTrendTransform(_OneSegmentChangePointsTrendTransform):
@@ -48,10 +59,13 @@ class _OneSegmentTrendTransform(_OneSegmentChangePointsTrendTransform):
 
 
 class TrendTransform(IrreversibleChangePointsTransform):
-    """TrendTransform adds trend as a feature.
+    """Transform that adds trend as a feature.
 
-    TrendTransform uses uses :py:class:`ruptures.detection.Binseg` model as a change point detection model
-    in _TrendTransform.
+    Transform divides each segment into intervals using ``change_points_model``.
+    Then a separate model is fitted on each interval using ``per_interval_model``.
+    New column is created with values predicted by the model of each interval.
+
+    Evaluated function can be linear, mean, median, etc. Look at the signature to find out which models can be used.
 
     Warning
     -------
@@ -62,7 +76,7 @@ class TrendTransform(IrreversibleChangePointsTransform):
     def __init__(
         self,
         in_column: str,
-        change_points_model: BaseChangePointsModelAdapter,
+        change_points_model: BaseChangePointsModelAdapter = None,
         per_interval_model: Optional[PerIntervalModel] = None,
         out_column: Optional[str] = None,
     ):
@@ -77,11 +91,21 @@ class TrendTransform(IrreversibleChangePointsTransform):
             If not given, use ``self.__repr__()``
         """
         self.in_column = in_column
+        self.out_column = out_column
+
+        self._is_change_points_model_default = change_points_model is None
+        self.change_points_model = (
+            change_points_model
+            if change_points_model is not None
+            else RupturesChangePointsModel(
+                change_points_model=Binseg(model="l2"),
+                n_bkps=5,
+            )
+        )
         self.per_interval_model = (
             SklearnRegressionPerIntervalModel() if per_interval_model is None else per_interval_model
         )
-        self.change_points_model = change_points_model
-        self.out_column = out_column
+
         super().__init__(
             transform=_OneSegmentTrendTransform(
                 in_column=self.in_column,
@@ -91,3 +115,25 @@ class TrendTransform(IrreversibleChangePointsTransform):
             ),
             required_features=[in_column],
         )
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        If ``change_points_model`` isn't set then this grid tunes parameters:
+        ``change_points_model.change_points_model.model``, ``change_points_model.n_bkps``.
+        Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        if self._is_change_points_model_default:
+            return {
+                "change_points_model.change_points_model.model": CategoricalDistribution(
+                    ["l1", "l2", "normal", "rbf", "cosine", "linear", "clinear", "ar", "mahalanobis", "rank"]
+                ),
+                "change_points_model.n_bkps": IntUniformDistribution(low=5, high=30),
+            }
+        else:
+            return {}

--- a/etna/transforms/decomposition/detrend.py
+++ b/etna/transforms/decomposition/detrend.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from typing import List
 
 import numpy as np
@@ -8,13 +9,18 @@ from sklearn.linear_model import TheilSenRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import PolynomialFeatures
 
+from etna import SETTINGS
 from etna.transforms.base import OneSegmentTransform
 from etna.transforms.base import ReversiblePerSegmentWrapper
 from etna.transforms.utils import match_target_quantiles
 
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import IntUniformDistribution
+
 
 class _OneSegmentLinearTrendBaseTransform(OneSegmentTransform):
-    """LinearTrendBaseTransform is a base class that implements trend subtraction and reconstruction feature."""
+    """Transform for one segment that implements trend subtraction and reconstruction feature."""
 
     def __init__(self, in_column: str, regressor: RegressorMixin, poly_degree: int = 1):
         """
@@ -137,8 +143,10 @@ class _OneSegmentLinearTrendBaseTransform(OneSegmentTransform):
 
 
 class LinearTrendTransform(ReversiblePerSegmentWrapper):
-    """
-    Transform that uses :py:class:`sklearn.linear_model.LinearRegression` to find linear or polynomial trend in data.
+    """Transform that uses linear regression with polynomial features to make a detrending.
+
+    Transform fits a :py:class:`sklearn.linear_model.LinearRegression` with polynomial features on each segment.
+    Values predicted by the model are subtracted from each segment.
 
     Warning
     -------
@@ -174,10 +182,26 @@ class LinearTrendTransform(ReversiblePerSegmentWrapper):
         """Return the list with regressors created by the transform."""
         return []
 
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes only ``poly_degree`` parameter. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "poly_degree": IntUniformDistribution(low=1, high=2),
+        }
+
 
 class TheilSenTrendTransform(ReversiblePerSegmentWrapper):
-    """
-    Transform that uses :py:class:`sklearn.linear_model.TheilSenRegressor` to find linear or polynomial trend in data.
+    """Transform that uses Theil–Sen regression with polynomial features to make a detrending.
+
+    Transform fits a :py:class:`sklearn.linear_model.TheilSenRegressor` with polynomial features on each segment.
+    Values predicted by the model are subtracted from each segment.
 
     Warning
     -------
@@ -217,3 +241,17 @@ class TheilSenTrendTransform(ReversiblePerSegmentWrapper):
     def get_regressors_info(self) -> List[str]:
         """Return the list with regressors created by the transform."""
         return []
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes only ``poly_degree`` parameter. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "poly_degree": IntUniformDistribution(low=1, high=2),
+        }

--- a/etna/transforms/decomposition/stl.py
+++ b/etna/transforms/decomposition/stl.py
@@ -11,9 +11,14 @@ from statsmodels.tsa.exponential_smoothing.ets import ETSModel
 from statsmodels.tsa.forecasting.stl import STLForecast
 from statsmodels.tsa.forecasting.stl import STLForecastResults
 
+from etna import SETTINGS
 from etna.transforms.base import OneSegmentTransform
 from etna.transforms.base import ReversiblePerSegmentWrapper
 from etna.transforms.utils import match_target_quantiles
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
 
 
 class _OneSegmentSTLTransform(OneSegmentTransform):
@@ -224,3 +229,18 @@ class STLTransform(ReversiblePerSegmentWrapper):
     def get_regressors_info(self) -> List[str]:
         """Return the list with regressors created by the transform."""
         return []
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``model``, ``robust``. Other parameters are expected to be set by the user.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "model": CategoricalDistribution(["arima", "holt"]),
+            "robust": CategoricalDistribution([False, True]),
+        }

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_detrend.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_detrend.py
@@ -112,6 +112,16 @@ def test_save_load(example_tsds):
                     n_bkps=5,
                 ),
             ),
+            2,
+        ),
+        (
+            ChangePointsTrendTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=10,
+                ),
+            ),
             0,
         ),
     ],

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_level.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_level.py
@@ -85,6 +85,16 @@ def test_save_load(ts_with_local_levels):
                     n_bkps=5,
                 ),
             ),
+            2,
+        ),
+        (
+            ChangePointsLevelTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=10,
+                ),
+            ),
             0,
         ),
     ],

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_level.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_level.py
@@ -9,6 +9,7 @@ from etna.datasets import TSDataset
 from etna.transforms import ChangePointsLevelTransform
 from etna.transforms.decomposition.change_points_based.change_points_models import RupturesChangePointsModel
 from etna.transforms.decomposition.change_points_based.per_interval_models import MeanPerIntervalModel
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -70,3 +71,25 @@ def test_save_load(ts_with_local_levels):
         per_interval_model=MeanPerIntervalModel(),
     )
     assert_transformation_equals_loaded_original(transform=transform, ts=ts_with_local_levels)
+
+
+@pytest.mark.parametrize(
+    "transform, expected_length",
+    [
+        (ChangePointsLevelTransform(in_column="target"), 2),
+        (
+            ChangePointsLevelTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=5,
+                ),
+            ),
+            0,
+        ),
+    ],
+)
+def test_params_to_tune(transform, expected_length, ts_with_local_levels):
+    ts = ts_with_local_levels
+    assert len(transform.params_to_tune()) == expected_length
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_segmentation.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_segmentation.py
@@ -146,6 +146,16 @@ def test_save_load(simple_ar_ts):
                     n_bkps=5,
                 ),
             ),
+            2,
+        ),
+        (
+            ChangePointsSegmentationTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=10,
+                ),
+            ),
             0,
         ),
     ],

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_trend.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_trend.py
@@ -11,6 +11,7 @@ from etna.transforms.decomposition import TrendTransform
 from etna.transforms.decomposition.change_points_based.change_points_models import RupturesChangePointsModel
 from etna.transforms.decomposition.change_points_based.per_interval_models import SklearnRegressionPerIntervalModel
 from etna.transforms.decomposition.change_points_based.trend import _OneSegmentTrendTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 DEFAULT_SEGMENT = "segment_1"
@@ -168,3 +169,25 @@ def test_save_load(example_tsds):
         change_points_model=RupturesChangePointsModel(change_points_model=Binseg(model="rbf"), n_bkps=5),
     )
     assert_transformation_equals_loaded_original(transform=transform, ts=example_tsds)
+
+
+@pytest.mark.parametrize(
+    "transform, expected_length",
+    [
+        (TrendTransform(in_column="target"), 2),
+        (
+            TrendTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=5,
+                ),
+            ),
+            0,
+        ),
+    ],
+)
+def test_params_to_tune(transform, expected_length, example_tsds):
+    ts = example_tsds
+    assert len(transform.params_to_tune()) == expected_length
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_decomposition/test_change_points_based/test_trend.py
+++ b/tests/test_transforms/test_decomposition/test_change_points_based/test_trend.py
@@ -183,6 +183,16 @@ def test_save_load(example_tsds):
                     n_bkps=5,
                 ),
             ),
+            2,
+        ),
+        (
+            TrendTransform(
+                in_column="target",
+                change_points_model=RupturesChangePointsModel(
+                    change_points_model=Binseg(model="ar"),
+                    n_bkps=10,
+                ),
+            ),
             0,
         ),
     ],

--- a/tests/test_transforms/test_decomposition/test_detrend_transform.py
+++ b/tests/test_transforms/test_decomposition/test_detrend_transform.py
@@ -11,6 +11,7 @@ from etna.datasets.tsdataset import TSDataset
 from etna.transforms.decomposition import LinearTrendTransform
 from etna.transforms.decomposition import TheilSenTrendTransform
 from etna.transforms.decomposition.detrend import _OneSegmentLinearTrendBaseTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 DEFAULT_SEGMENT = "segment_1"
@@ -377,3 +378,13 @@ def test_fit_transform_with_nans(transformer, ts_with_nans, decimal):
 def test_save_load(transform, ts_two_segments_linear):
     ts = ts_two_segments_linear
     assert_transformation_equals_loaded_original(transform=transform, ts=ts)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [LinearTrendTransform(in_column="target"), TheilSenTrendTransform(in_column="target")],
+)
+def test_params_to_tune(transform, ts_two_segments_linear):
+    ts = ts_two_segments_linear
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)

--- a/tests/test_transforms/test_decomposition/test_stl_transform.py
+++ b/tests/test_transforms/test_decomposition/test_stl_transform.py
@@ -6,6 +6,7 @@ from etna.datasets.tsdataset import TSDataset
 from etna.models import NaiveModel
 from etna.transforms.decomposition import STLTransform
 from etna.transforms.decomposition.stl import _OneSegmentSTLTransform
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -197,3 +198,10 @@ def test_fit_transform_with_nans_in_middle_raise_error(ts_with_nans):
 )
 def test_save_load(transform, ts_trend_seasonal):
     assert_transformation_equals_loaded_original(transform=transform, ts=ts_trend_seasonal)
+
+
+def test_params_to_tune(ts_trend_seasonal):
+    ts = ts_trend_seasonal
+    transform = STLTransform(in_column="target", period=7)
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #1227.

## Closing issues
Closes #1227.
