### PR TITLE
Add default `params_to_tune` for feature selection transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add default `params_to_tune` for `TimeSeriesImputerTransform` ([#1232](https://github.com/tinkoff-ai/etna/pull/1232))
 - Add default `params_to_tune` for `DifferencingTransform`, `MedianTransform`, `MaxTransform`, `MinTransform`, `QuantileTransform`, `StdTransform`, `MeanTransform`, `MADTransform`, `MinMaxDifferenceTransform`, `SumTransform`, `BoxCoxTransform`, `YeoJohnsonTransform`, `MaxAbsScalerTransform`, `MinMaxScalerTransform`, `RobustScalerTransform` and `StandardScalerTransform` ([#1233](https://github.com/tinkoff-ai/etna/pull/1233))
 - Add default `params_to_tune` for `LabelEncoderTransform` ([#1242](https://github.com/tinkoff-ai/etna/pull/1242))
+- Add default `params_to_tune` for `TreeFeatureSelectionTransform`, `MRMRFeatureSelectionTransform` and `GaleShapleyFeatureSelectionTransform` ([#1250](https://github.com/tinkoff-ai/etna/pull/1250))
 ### Fixed
 - Fix bug in `GaleShapleyFeatureSelectionTransform` with wrong number of remaining features ([#1110](https://github.com/tinkoff-ai/etna/pull/1110))
 - `ProphetModel` fails with additional seasonality set ([#1157](https://github.com/tinkoff-ai/etna/pull/1157))

--- a/etna/transforms/feature_selection/feature_importance.py
+++ b/etna/transforms/feature_selection/feature_importance.py
@@ -63,9 +63,10 @@ class TreeFeatureSelectionTransform(BaseFeatureSelectionTransform):
             (e.g. all tree-based regressors in sklearn).
             Pre-defined options are also available:
 
-            * catboost: ``catboost.CatBoostRegressor(silent=True)``, this model won't work if there are any category types
+            * catboost: ``catboost.CatBoostRegressor(iterations=1000, silent=True)``,
+            this model won't work if there are any category types
 
-            * random_forest: ``sklearn.ensemble.RandomForestRegressor(random_state=0)``
+            * random_forest: ``sklearn.ensemble.RandomForestRegressor(n_estimators=100, random_state=0)``
 
         top_k:
             num of features to select; if there are not enough features, then all will be selected
@@ -80,7 +81,7 @@ class TreeFeatureSelectionTransform(BaseFeatureSelectionTransform):
         self.top_k = top_k
         if isinstance(model, str):
             if model == "catboost":
-                self.model = CatBoostRegressor(silent=True)
+                self.model = CatBoostRegressor(iterations=1000, silent=True)
             elif model == "random_forest":
                 self.model = RandomForestRegressor(random_state=0)
             else:

--- a/etna/transforms/feature_selection/gale_shapley.py
+++ b/etna/transforms/feature_selection/gale_shapley.py
@@ -8,9 +8,15 @@ from typing import Union
 import pandas as pd
 from typing_extensions import Literal
 
+from etna import SETTINGS
 from etna.analysis import RelevanceTable
 from etna.core import BaseMixin
 from etna.transforms.feature_selection.base import BaseFeatureSelectionTransform
+
+if SETTINGS.auto_required:
+    from optuna.distributions import BaseDistribution
+    from optuna.distributions import CategoricalDistribution
+    from optuna.distributions import IntUniformDistribution
 
 
 class BaseGaleShapley(BaseMixin):
@@ -385,3 +391,20 @@ class GaleShapleyFeatureSelectionTransform(BaseFeatureSelectionTransform):
                 segment_features_ranking=segment_features_ranking, features_to_drop=selected_features
             )
         return self
+
+    def params_to_tune(self) -> Dict[str, "BaseDistribution"]:
+        """Get default grid for tuning hyperparameters.
+
+        This grid tunes parameters: ``top_k``, ``use_rank``. Other parameters are expected to be set by the user.
+
+        For ``top_k`` parameter the maximum suggested value is not greater than ``self.top_k``.
+
+        Returns
+        -------
+        :
+            Grid to tune.
+        """
+        return {
+            "top_k": IntUniformDistribution(low=1, high=self.top_k),
+            "use_rank": CategoricalDistribution([False, True]),
+        }

--- a/tests/test_transforms/test_feature_selection/test_feature_importance_transform.py
+++ b/tests/test_transforms/test_feature_selection/test_feature_importance_transform.py
@@ -122,14 +122,14 @@ def test_work_with_non_regressors(ts_with_exog, model):
         RandomForestRegressor(n_estimators=10, random_state=42),
         ExtraTreesRegressor(n_estimators=10, random_state=42),
         GradientBoostingRegressor(n_estimators=10, random_state=42),
-        CatBoostRegressor(iterations=10, random_state=42, silent=True, cat_features=["segment_code"]),
+        CatBoostRegressor(iterations=10, random_state=42, silent=True),
     ],
 )
 @pytest.mark.parametrize("top_k", [0, 1, 5, 15, 50])
-def test_selected_top_k_regressors(model, top_k, ts_with_regressors_and_features):
+def test_selected_top_k_regressors(model, top_k, ts_with_regressors):
     """Check that transform selects exactly top_k regressors if where are this much."""
-    ts = ts_with_regressors_and_features
-    all_regressors = ts_with_regressors_and_features.regressors
+    ts = ts_with_regressors
+    all_regressors = ts_with_regressors.regressors
     selector = TreeFeatureSelectionTransform(model=model, top_k=top_k)
     selector.fit_transform(ts)
 
@@ -147,13 +147,13 @@ def test_selected_top_k_regressors(model, top_k, ts_with_regressors_and_features
         RandomForestRegressor(n_estimators=10, random_state=42),
         ExtraTreesRegressor(n_estimators=10, random_state=42),
         GradientBoostingRegressor(n_estimators=10, random_state=42),
-        CatBoostRegressor(iterations=10, random_state=42, silent=True, cat_features=["segment_code"]),
+        CatBoostRegressor(iterations=10, random_state=42, silent=True),
     ],
 )
 @pytest.mark.parametrize("top_k", [0, 1, 5, 15, 50])
-def test_retain_values(model, top_k, ts_with_regressors_and_features):
+def test_retain_values(model, top_k, ts_with_regressors):
     """Check that transform doesn't change values of columns."""
-    ts = ts_with_regressors_and_features
+    ts = ts_with_regressors
     df_encoded = ts.to_pandas()
     selector = TreeFeatureSelectionTransform(model=model, top_k=top_k)
     df_selected = selector.fit_transform(ts).to_pandas()
@@ -216,13 +216,13 @@ def test_warns_no_regressors(model, example_tsds):
         RandomForestRegressor(n_estimators=10, random_state=42),
         ExtraTreesRegressor(n_estimators=10, random_state=42),
         GradientBoostingRegressor(n_estimators=10, random_state=42),
-        CatBoostRegressor(iterations=700, random_state=42, silent=True, cat_features=["segment_code"]),
+        CatBoostRegressor(iterations=700, random_state=42, silent=True),
     ],
 )
-def test_sanity_selected(model, ts_with_regressors_and_features):
+def test_sanity_selected(model, ts_with_regressors):
     """Check that transform correctly finds meaningful regressors."""
-    ts = ts_with_regressors_and_features
-    selector = TreeFeatureSelectionTransform(model=model, top_k=8)
+    ts = ts_with_regressors
+    selector = TreeFeatureSelectionTransform(model=model, top_k=10)
     df_selected = selector.fit_transform(ts).to_pandas()
     features_columns = df_selected.columns.get_level_values("feature").unique()
     selected_regressors = [column for column in features_columns if column.startswith("regressor_")]

--- a/tests/test_transforms/test_feature_selection/test_feature_importance_transform.py
+++ b/tests/test_transforms/test_feature_selection/test_feature_importance_transform.py
@@ -95,6 +95,7 @@ def test_work_with_non_regressors(ts_with_exog, model):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),
@@ -123,6 +124,7 @@ def test_selected_top_k_regressors(model, top_k, ts_with_regressors):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),
@@ -152,6 +154,7 @@ def test_retain_values(model, top_k, ts_with_regressors):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),
@@ -192,6 +195,7 @@ def test_warns_no_regressors(model, example_tsds):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),
@@ -217,6 +221,7 @@ def test_sanity_selected(model, ts_with_regressors):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),
@@ -247,6 +252,7 @@ def test_sanity_model(model, ts_with_regressors):
     "model",
     [
         "random_forest",
+        "catboost",
         DecisionTreeRegressor(random_state=42),
         ExtraTreeRegressor(random_state=42),
         RandomForestRegressor(n_estimators=10, random_state=42),

--- a/tests/test_transforms/test_feature_selection/test_filter_transform.py
+++ b/tests/test_transforms/test_feature_selection/test_filter_transform.py
@@ -201,3 +201,16 @@ def test_inverse_transform_back_included_columns(ts_with_features, columns, retu
 )
 def test_save_load(transform, ts_with_features):
     assert_transformation_equals_loaded_original(transform=transform, ts=ts_with_features)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        FilterFeaturesTransform(include=["target"], return_features=True),
+        FilterFeaturesTransform(include=["target"], return_features=False),
+        FilterFeaturesTransform(exclude=["exog_1", "exog_2"], return_features=False),
+        FilterFeaturesTransform(exclude=["exog_1", "exog_2"], return_features=False),
+    ],
+)
+def test_params_to_tune(transform):
+    assert len(transform.params_to_tune()) == 0

--- a/tests/test_transforms/test_feature_selection/test_gale_shapley_transform.py
+++ b/tests/test_transforms/test_feature_selection/test_gale_shapley_transform.py
@@ -16,6 +16,7 @@ from etna.transforms.feature_selection.gale_shapley import BaseGaleShapley
 from etna.transforms.feature_selection.gale_shapley import FeatureGaleShapley
 from etna.transforms.feature_selection.gale_shapley import GaleShapleyMatcher
 from etna.transforms.feature_selection.gale_shapley import SegmentGaleShapley
+from tests.test_transforms.utils import assert_sampling_is_valid
 from tests.test_transforms.utils import assert_transformation_equals_loaded_original
 
 
@@ -659,3 +660,18 @@ def test_right_number_features_with_integer_division(ts_with_exog_galeshapley):
 
     remaining_columns = ts.columns.get_level_values("feature").unique().tolist()
     assert len(remaining_columns) == top_k + 1
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        GaleShapleyFeatureSelectionTransform(
+            relevance_table=ModelRelevanceTable(), top_k=3, use_rank=False, model=RandomForestRegressor(random_state=42)
+        ),
+        GaleShapleyFeatureSelectionTransform(relevance_table=StatisticsRelevanceTable(), top_k=3, use_rank=False),
+    ],
+)
+def test_params_to_tune(transform, ts_with_large_regressors_number):
+    ts = ts_with_large_regressors_number
+    assert len(transform.params_to_tune()) > 0
+    assert_sampling_is_valid(transform=transform, ts=ts)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #1223. We forgot there about mrmr.

## Closing issues
Closes #1223.