### PR TITLE
Fix `DeepARModel` and `TFTModel` to work with changed `prediction_size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add deep copy for copying attributes of `TSDataset` ([#1241](https://github.com/tinkoff-ai/etna/pull/1241))
 -
 - Add `tsfresh` into optional dependencies, remove instruction about `pip install tsfresh` ([#1246](https://github.com/tinkoff-ai/etna/pull/1246))
--
+- Fix `DeepARModel` and `TFTModel` to work with changed `prediction_size` ([#1251](https://github.com/tinkoff-ai/etna/pull/1251))
 
 ## [2.0.0] - 2023-04-11
 ### Added

--- a/tests/test_models/nn/test_deepar.py
+++ b/tests/test_models/nn/test_deepar.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+from lightning_fabric.utilities.seed import seed_everything
 from pytorch_forecasting.data import GroupNormalizer
 
 from etna.datasets.tsdataset import TSDataset
@@ -139,19 +140,17 @@ def test_forecast_model_equals_pipeline(example_tsds):
     horizon = 10
     pfdb = _get_default_dataset_builder(horizon)
 
-    import torch  # TODO: remove after fix at issue-802
-
-    torch.manual_seed(11)
     model = DeepARModel(dataset_builder=pfdb, trainer_params=dict(max_epochs=2), lr=0.1)
+    seed_everything(0)
     model.fit(example_tsds)
     future = example_tsds.make_future(future_steps=horizon, tail_steps=pfdb.max_encoder_length)
     forecast_model = model.forecast(
         ts=future, prediction_size=horizon, prediction_interval=True, quantiles=[0.02, 0.98]
     )
 
-    torch.manual_seed(11)
     model = DeepARModel(dataset_builder=pfdb, trainer_params=dict(max_epochs=2), lr=0.1)
     pipeline = Pipeline(model=model, transforms=[], horizon=horizon)
+    seed_everything(0)
     pipeline.fit(example_tsds)
     forecast_pipeline = pipeline.forecast(prediction_interval=True, quantiles=[0.02, 0.98])
 

--- a/tests/test_models/nn/test_tft.py
+++ b/tests/test_models/nn/test_tft.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+from lightning_fabric.utilities.seed import seed_everything
 
 from etna.metrics import MAE
 from etna.models.nn import TFTModel
@@ -144,19 +145,17 @@ def test_forecast_model_equals_pipeline(example_tsds):
     horizon = 10
     pfdb = _get_default_dataset_builder(horizon)
 
-    import torch  # TODO: remove after fix at issue-802
-
-    torch.manual_seed(11)
     model = TFTModel(dataset_builder=pfdb, trainer_params=dict(max_epochs=8), lr=0.1)
+    seed_everything(0)
     model.fit(example_tsds)
     future = example_tsds.make_future(future_steps=horizon, tail_steps=pfdb.max_encoder_length)
     forecast_model = model.forecast(
         ts=future, prediction_size=horizon, prediction_interval=True, quantiles=[0.02, 0.98]
     )
 
-    torch.manual_seed(11)
     model = TFTModel(dataset_builder=pfdb, trainer_params=dict(max_epochs=8), lr=0.1)
     pipeline = Pipeline(model=model, transforms=[], horizon=horizon)
+    seed_everything(0)
     pipeline.fit(example_tsds)
     forecast_pipeline = pipeline.forecast(prediction_interval=True, quantiles=[0.02, 0.98])
 

--- a/tests/test_models/test_inference/common.py
+++ b/tests/test_models/test_inference/common.py
@@ -1,4 +1,5 @@
 import numpy as np
+from lightning_fabric.utilities.seed import seed_everything
 from typing_extensions import get_args
 
 from etna.datasets import TSDataset
@@ -7,6 +8,7 @@ from etna.models import ContextRequiredModelType
 
 def make_prediction(model, ts, prediction_size, method_name) -> TSDataset:
     method = getattr(model, method_name)
+    seed_everything(0)
     if isinstance(model, get_args(ContextRequiredModelType)):
         ts = method(ts, prediction_size=prediction_size)
     else:

--- a/tests/test_models/test_inference/test_forecast.py
+++ b/tests/test_models/test_inference/test_forecast.py
@@ -506,18 +506,6 @@ class TestForecastOutSamplePrefix:
                 MLPModel(input_size=2, hidden_size=[10], decoder_length=7, trainer_params=dict(max_epochs=1)),
                 [LagTransform(in_column="target", lags=[5, 6])],
             ),
-        ],
-    )
-    def test_forecast_out_sample_prefix(self, model, transforms, example_tsds):
-        self._test_forecast_out_sample_prefix(example_tsds, model, transforms)
-
-    @to_be_fixed(
-        raises=AssertionError,
-        match="filters should not remove entries all entries - check encoder/decoder lengths and lags",
-    )
-    @pytest.mark.parametrize(
-        "model, transforms",
-        [
             (
                 DeepARModel(
                     dataset_builder=PytorchForecastingDatasetBuilder(
@@ -550,7 +538,7 @@ class TestForecastOutSamplePrefix:
             ),
         ],
     )
-    def test_forecast_out_sample_prefix_failed_old_nns(self, model, transforms, example_tsds):
+    def test_forecast_out_sample_prefix(self, model, transforms, example_tsds):
         self._test_forecast_out_sample_prefix(example_tsds, model, transforms)
 
 
@@ -640,10 +628,9 @@ class TestForecastOutSampleSuffix:
         with pytest.raises(AssertionError):
             self._test_forecast_out_sample_suffix(example_tsds, model, transforms)
 
-    # it even can't reach NotImplementedError
     @to_be_fixed(
-        raises=AssertionError,
-        match="filters should not remove entries all entries - check encoder/decoder lengths and lags",
+        raises=NotImplementedError,
+        match="You can only forecast from the next point after the last one in the training dataset",
     )
     @pytest.mark.parametrize(
         "model, transforms",

--- a/tests/test_models/test_inference/test_forecast.py
+++ b/tests/test_models/test_inference/test_forecast.py
@@ -463,18 +463,12 @@ class TestForecastOutSamplePrefix:
         model.fit(ts)
 
         # forecasting full
-        import torch  # TODO: remove after fix at issue-802
-
-        torch.manual_seed(11)
-
         forecast_full_ts = ts.make_future(
             future_steps=full_prediction_size, tail_steps=model.context_size, transforms=transforms
         )
         forecast_full_ts = make_forecast(model=model, ts=forecast_full_ts, prediction_size=full_prediction_size)
 
         # forecasting only prefix
-        torch.manual_seed(11)  # TODO: remove after fix at issue-802
-
         forecast_prefix_ts = ts.make_future(
             future_steps=full_prediction_size, tail_steps=model.context_size, transforms=transforms
         )
@@ -806,18 +800,12 @@ class TestForecastSubsetSegments:
         model.fit(ts)
 
         # forecasting full
-        import torch  # TODO: remove after fix at issue-802
-
-        torch.manual_seed(11)
-
         forecast_full_ts = ts.make_future(
             future_steps=prediction_size, tail_steps=model.context_size, transforms=transforms
         )
         forecast_full_ts = make_forecast(model=model, ts=forecast_full_ts, prediction_size=prediction_size)
 
         # forecasting subset of segments
-        torch.manual_seed(11)  # TODO: remove after fix at issue-802
-
         forecast_subset_ts = subset_ts.make_future(
             future_steps=prediction_size, tail_steps=model.context_size, transforms=transforms
         )
@@ -918,10 +906,6 @@ class TestForecastNewSegments:
         model.fit(train_ts)
 
         # forecasting
-        import torch  # TODO: remove after fix at issue-802
-
-        torch.manual_seed(11)
-
         forecast_ts = test_ts.make_future(
             future_steps=prediction_size, tail_steps=model.context_size, transforms=transforms
         )

--- a/tests/test_models/test_inference/test_predict.py
+++ b/tests/test_models/test_inference/test_predict.py
@@ -677,16 +677,10 @@ class TestPredictSubsetSegments:
         model.fit(ts)
 
         # forecasting full
-        import torch  # TODO: remove after fix at issue-802
-
-        torch.manual_seed(11)
-
         ts.df = ts.df.iloc[(num_skip_points - model.context_size) :]
         forecast_full_ts = make_predict(model=model, ts=ts, prediction_size=prediction_size)
 
         # forecasting subset of segments
-        torch.manual_seed(11)  # TODO: remove after fix at issue-802
-
         subset_ts.df = subset_ts.df.iloc[(num_skip_points - model.context_size) :]
         forecast_subset_ts = make_predict(model=model, ts=subset_ts, prediction_size=prediction_size)
 
@@ -786,10 +780,6 @@ class TestPredictNewSegments:
         model.fit(train_ts)
 
         # forecasting
-        import torch  # TODO: remove after fix at issue-802
-
-        torch.manual_seed(11)
-
         test_ts.df = test_ts.df.iloc[(num_skip_points - model.context_size) :]
         prediction_size = len(ts.index) - num_skip_points
         forecast_ts = make_predict(model=model, ts=test_ts, prediction_size=prediction_size)

--- a/tests/test_models/utils.py
+++ b/tests/test_models/utils.py
@@ -4,6 +4,7 @@ from typing import Sequence
 from typing import Tuple
 
 import pandas as pd
+from lightning_fabric.utilities.seed import seed_everything
 
 from etna.datasets import TSDataset
 from etna.models.base import ModelType
@@ -23,16 +24,15 @@ def get_loaded_model(model: ModelType) -> ModelType:
 def assert_model_equals_loaded_original(
     model: ModelType, ts: TSDataset, transforms: Sequence[Transform], horizon: int
 ) -> Tuple[ModelType, ModelType]:
-    import torch  # TODO: remove after fix at issue-802
 
     pipeline_1 = Pipeline(model=model, transforms=transforms, horizon=horizon)
     pipeline_1.fit(ts)
-    torch.manual_seed(11)
+    seed_everything(0)
     forecast_ts_1 = pipeline_1.forecast()
 
     loaded_model = get_loaded_model(pipeline_1.model)
     pipeline_1.model = loaded_model
-    torch.manual_seed(11)
+    seed_everything(0)
     forecast_ts_2 = pipeline_1.forecast()
 
     pd.testing.assert_frame_equal(forecast_ts_1.to_pandas(), forecast_ts_2.to_pandas())

--- a/tests/test_pipeline/utils.py
+++ b/tests/test_pipeline/utils.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from typing import Tuple
 
 import pandas as pd
+from lightning_fabric.utilities.seed import seed_everything
 
 from etna.datasets import TSDataset
 from etna.pipeline.base import AbstractPipeline
@@ -24,21 +25,20 @@ def get_loaded_pipeline(pipeline: AbstractPipeline, ts: TSDataset = None) -> Abs
 def assert_pipeline_equals_loaded_original(
     pipeline: AbstractPipeline, ts: TSDataset, load_ts: bool = True
 ) -> Tuple[AbstractPipeline, AbstractPipeline]:
-    import torch  # TODO: remove after fix at issue-802
 
     initial_ts = deepcopy(ts)
 
     pipeline.fit(ts)
-    torch.manual_seed(11)
+    seed_everything(0)
     forecast_ts_1 = pipeline.forecast()
 
     if load_ts:
         loaded_pipeline = get_loaded_pipeline(pipeline, ts=initial_ts)
-        torch.manual_seed(11)
+        seed_everything(0)
         forecast_ts_2 = loaded_pipeline.forecast()
     else:
         loaded_pipeline = get_loaded_pipeline(pipeline)
-        torch.manual_seed(11)
+        seed_everything(0)
         forecast_ts_2 = loaded_pipeline.forecast(ts=initial_ts)
 
     pd.testing.assert_frame_equal(forecast_ts_1.to_pandas(), forecast_ts_2.to_pandas())


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
1. Keep the non-deterministic behavior of `DeepARModel`. If someone wants to make it deterministic he can use `seed_everything`.
2. Fix some inference tests to work with changed prediction horizon.

## Closing issues
Closes #802.
