### PR TITLE
Remove `to_be_fixed` from inference tests on `SpecialDaysTransform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update requirements for `holidays` and `scipy`, change saving library from `pickle` to `dill` in `SaveMixin` ([#1268](https://github.com/tinkoff-ai/etna/pull/1268))
 - Update requirement for `ruptures`, add requirement for `sqlalchemy` ([#1276](https://github.com/tinkoff-ai/etna/pull/1276))
 - Optimize `make_samples` of `RNNNet` and `MLPNet` ([#1281](https://github.com/tinkoff-ai/etna/pull/1281))
+- Remove `to_be_fixed` from inference tests on `SpecialDaysTransform` ([#1283](https://github.com/tinkoff-ai/etna/pull/1283))
+- 
+- 
 - 
 ### Fixed
 - Fix `plot_backtest` and `plot_backtest_interactive` on one-step forecast ([1260](https://github.com/tinkoff-ai/etna/pull/1260))

--- a/tests/test_transforms/test_inference/test_inverse_transform.py
+++ b/tests/test_transforms/test_inference/test_inverse_transform.py
@@ -691,6 +691,8 @@ class TestInverseTransformTrainNewSegments:
             (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
             (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
             (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
+            # timestamp
+            (SpecialDaysTransform(), "regular_ts"),
         ],
     )
     def test_inverse_transform_train_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -699,20 +701,6 @@ class TestInverseTransformTrainNewSegments:
             self._test_inverse_transform_train_new_segments(
                 ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
             )
-
-    @to_be_fixed(raises=NotImplementedError, match="Per-segment transforms can't work on new segments")
-    @pytest.mark.parametrize(
-        "transform, dataset_name",
-        [
-            # timestamp
-            (SpecialDaysTransform(), "regular_ts"),
-        ],
-    )
-    def test_inverse_transform_train_new_segments_failed_not_implemented(self, transform, dataset_name, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_inverse_transform_train_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
 
 
 class TestInverseTransformFutureNewSegments:
@@ -1027,6 +1015,8 @@ class TestInverseTransformFutureNewSegments:
             (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
             (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
             (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
+            # timestamp
+            (SpecialDaysTransform(), "regular_ts"),
         ],
     )
     def test_inverse_transform_future_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -1035,20 +1025,6 @@ class TestInverseTransformFutureNewSegments:
             self._test_inverse_transform_future_new_segments(
                 ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
             )
-
-    @to_be_fixed(raises=NotImplementedError, match="Per-segment transforms can't work on new segments")
-    @pytest.mark.parametrize(
-        "transform, dataset_name",
-        [
-            # timestamp
-            (SpecialDaysTransform(), "regular_ts"),
-        ],
-    )
-    def test_inverse_transform_future_new_segments_failed_not_implemented(self, transform, dataset_name, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_inverse_transform_future_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
 
     @to_be_fixed(raises=Exception)
     @pytest.mark.parametrize(

--- a/tests/test_transforms/test_inference/test_transform.py
+++ b/tests/test_transforms/test_inference/test_transform.py
@@ -56,7 +56,6 @@ from etna.transforms import YeoJohnsonTransform
 from etna.transforms.decomposition import RupturesChangePointsModel
 from tests.test_transforms.test_inference.common import find_columns_diff
 from tests.utils import select_segments_subset
-from tests.utils import to_be_fixed
 
 # TODO: figure out what happened to TrendTransform
 
@@ -652,6 +651,8 @@ class TestTransformTrainNewSegments:
             (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
             (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
             (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
+            # timestamp
+            (SpecialDaysTransform(), "regular_ts"),
         ],
     )
     def test_transform_train_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -660,20 +661,6 @@ class TestTransformTrainNewSegments:
             self._test_transform_train_new_segments(
                 ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
             )
-
-    @to_be_fixed(raises=NotImplementedError, match="Per-segment transforms can't work on new segments")
-    @pytest.mark.parametrize(
-        "transform, dataset_name",
-        [
-            # timestamp
-            (SpecialDaysTransform(), "regular_ts"),
-        ],
-    )
-    def test_transform_train_new_segments_failed_not_implemented(self, transform, dataset_name, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_transform_train_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
 
 
 class TestTransformFutureNewSegments:
@@ -981,6 +968,8 @@ class TestTransformFutureNewSegments:
             (DensityOutliersTransform(in_column="target"), "ts_with_outliers"),
             (MedianOutliersTransform(in_column="target"), "ts_with_outliers"),
             (PredictionIntervalOutliersTransform(in_column="target", model=ProphetModel), "ts_with_outliers"),
+            # timestamp
+            (SpecialDaysTransform(), "regular_ts"),
         ],
     )
     def test_transform_future_new_segments_not_implemented(self, transform, dataset_name, request):
@@ -989,20 +978,6 @@ class TestTransformFutureNewSegments:
             self._test_transform_future_new_segments(
                 ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
             )
-
-    @to_be_fixed(raises=NotImplementedError, match="Per-segment transforms can't work on new segments")
-    @pytest.mark.parametrize(
-        "transform, dataset_name",
-        [
-            # timestamp
-            (SpecialDaysTransform(), "regular_ts"),
-        ],
-    )
-    def test_transform_future_new_segments_failed_not_implemented(self, transform, dataset_name, request):
-        ts = request.getfixturevalue(dataset_name)
-        self._test_transform_future_new_segments(
-            ts, transform, train_segments=["segment_1", "segment_2"], expected_changes={}
-        )
 
 
 class TestTransformFutureWithTarget:


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes

Remove `to_be_fixed` from inference tests on `SpecialDaysTransform`.

## Closing issues
#1113 --- it should be closed as not planned.
