### PR TITLE
Fix `BasePipeline.forecast` when prediction intervals are estimated on history data with presence of NaNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix problems with flake8 B023 ([#1252](https://github.com/tinkoff-ai/etna/pull/1252))
 - Fix problem with swapped forecast methods in HierarchicalPipeline ([#1259](https://github.com/tinkoff-ai/etna/pull/1259))
 - Fix problem with segment name "target" in `StackingEnsemble` ([#1262](https://github.com/tinkoff-ai/etna/pull/1262))
-- Fix `BasePipeline.forecast` when prediction intervals are estimated on history data with presence of NaNs ([]())
+- Fix `BasePipeline.forecast` when prediction intervals are estimated on history data with presence of NaNs ([#1291](https://github.com/tinkoff-ai/etna/pull/1291))
 
 ## [2.0.0] - 2023-04-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix problems with flake8 B023 ([#1252](https://github.com/tinkoff-ai/etna/pull/1252))
 - Fix problem with swapped forecast methods in HierarchicalPipeline ([#1259](https://github.com/tinkoff-ai/etna/pull/1259))
 - Fix problem with segment name "target" in `StackingEnsemble` ([#1262](https://github.com/tinkoff-ai/etna/pull/1262))
+- Fix `BasePipeline.forecast` when prediction intervals are estimated on history data with presence of NaNs ([]())
 
 ## [2.0.0] - 2023-04-11
 ### Added

--- a/etna/pipeline/base.py
+++ b/etna/pipeline/base.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from abc import abstractmethod
 from copy import deepcopy
 from enum import Enum
@@ -23,7 +24,6 @@ from etna.core import AbstractSaveable
 from etna.core import BaseMixin
 from etna.datasets import TSDataset
 from etna.loggers import tslogger
-from etna.metrics import MAE
 from etna.metrics import Metric
 from etna.metrics import MetricAggregationMode
 
@@ -283,6 +283,29 @@ class FoldParallelGroup(TypedDict):
     forecast_masks: List[FoldMask]
 
 
+class _DummyMetric(Metric):
+    """Dummy metric that is created only for implementation of BasePipeline._forecast_prediction_interval."""
+
+    def __init__(self, mode: str = MetricAggregationMode.per_segment, **kwargs):
+        super().__init__(mode=mode, metric_fn=self._compute_metric, **kwargs)
+
+    @staticmethod
+    def _compute_metric(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        return 0.0
+
+    @property
+    def greater_is_better(self) -> bool:
+        return False
+
+    def __call__(self, y_true: TSDataset, y_pred: TSDataset) -> Union[float, Dict[str, float]]:
+        segments = set(y_true.df.columns.get_level_values("segment"))
+        metrics_per_segment = {}
+        for segment in segments:
+            metrics_per_segment[segment] = 0.0
+        metrics = self._aggregate_metrics(metrics_per_segment)
+        return metrics
+
+
 class BasePipeline(AbstractPipeline, BaseMixin):
     """Base class for pipeline."""
 
@@ -315,7 +338,7 @@ class BasePipeline(AbstractPipeline, BaseMixin):
     ) -> TSDataset:
         """Add prediction intervals to the forecasts."""
         with tslogger.disable():
-            _, forecasts, _ = self.backtest(ts=ts, metrics=[MAE()], n_folds=n_folds)
+            _, forecasts, _ = self.backtest(ts=ts, metrics=[_DummyMetric()], n_folds=n_folds)
 
         self._add_forecast_borders(ts=ts, backtest_forecasts=forecasts, quantiles=quantiles, predictions=predictions)
 
@@ -331,7 +354,25 @@ class BasePipeline(AbstractPipeline, BaseMixin):
             - ts[backtest_forecasts.index.min() : backtest_forecasts.index.max(), :, "target"]
         )
 
-        sigma = np.std(residuals.values, axis=0)
+        len_backtest, num_segments = residuals.shape
+        min_timestamp = backtest_forecasts.index.min()
+        max_timestamp = backtest_forecasts.index.max()
+        non_nan_counts = np.sum(~np.isnan(residuals.values), axis=0)
+        if np.any(non_nan_counts < len_backtest):
+            warnings.warn(
+                f"There are NaNs in target on time span from {min_timestamp} to {max_timestamp}. "
+                f"It can obstruct prediction interval estimation on history data."
+            )
+        if np.any(non_nan_counts < 2):
+            raise ValueError(
+                f"There aren't enough target values to evaluate prediction intervals on history! "
+                f"For each segment there should be at least 2 points with defined value in a "
+                f"time span from {min_timestamp} to {max_timestamp}. "
+                f"You can try to increase n_folds parameter to make time span bigger or fill unknown target values."
+            )
+
+        sigma = np.nanstd(residuals.values, axis=0)
+
         borders = []
         for quantile in quantiles:
             z_q = norm.ppf(q=quantile)

--- a/tests/test_pipeline/test_hierarchical_pipeline.py
+++ b/tests/test_pipeline/test_hierarchical_pipeline.py
@@ -412,9 +412,9 @@ def test_interval_metrics(product_level_constant_hierarchical_ts, metric_type, r
     results, _, _ = pipeline.backtest(
         ts=ts,
         metrics=[metric],
-        n_folds=2,
+        n_folds=1,
         aggregate_metrics=True,
-        forecast_params={"prediction_interval": True, "n_folds": 1},
+        forecast_params={"prediction_interval": True, "n_folds": 2},
     )
     np.testing.assert_allclose(results[metric.name], answer)
 


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look #899.

## Closing issues
Closes #899.