### PR TITLE
Add inverse transformation into `predict` method of pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - `mrmr` feature selection working with categoricals ([#1311](https://github.com/tinkoff-ai/etna/pull/1311))
 - Fix version of `statsforecast` to 1.4 to avoid dependency conflicts during installation ([#1313](https://github.com/tinkoff-ai/etna/pull/1313))
+- Add inverse transformation into `predict` method of pipelines ([]())
 
 ### Removed
 - Building docker images with cuda 10.2 ([#1306](https://github.com/tinkoff-ai/etna/pull/1306))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 - `mrmr` feature selection working with categoricals ([#1311](https://github.com/tinkoff-ai/etna/pull/1311))
 - Fix version of `statsforecast` to 1.4 to avoid dependency conflicts during installation ([#1313](https://github.com/tinkoff-ai/etna/pull/1313))
-- Add inverse transformation into `predict` method of pipelines ([]())
+- Add inverse transformation into `predict` method of pipelines ([#1314](https://github.com/tinkoff-ai/etna/pull/1314))
 
 ### Removed
 - Building docker images with cuda 10.2 ([#1306](https://github.com/tinkoff-ai/etna/pull/1306))

--- a/etna/pipeline/mixins.py
+++ b/etna/pipeline/mixins.py
@@ -105,6 +105,8 @@ class ModelPipelinePredictMixin:
             )
         else:
             raise NotImplementedError(f"Unknown model type: {self.model.__class__.__name__}!")
+
+        results.inverse_transform(self.transforms)
         return results
 
 

--- a/tests/test_pipeline/test_autoregressive_pipeline.py
+++ b/tests/test_pipeline/test_autoregressive_pipeline.py
@@ -260,7 +260,7 @@ def test_backtest_forecasts_sanity(step_ts: TSDataset):
         (ProphetModel(), []),
     ],
 )
-def test_predict(model, transforms, example_tsds):
+def test_predict_format(model, transforms, example_tsds):
     ts = example_tsds
     pipeline = AutoRegressivePipeline(model=model, transforms=transforms, horizon=7)
     pipeline.fit(ts)
@@ -280,6 +280,23 @@ def test_predict(model, transforms, example_tsds):
 
     assert not np.any(result_df["target"].isna())
     assert len(result_df) == len(example_tsds.segments) * num_points
+
+
+def test_predict_values(example_tsds):
+    original_ts = deepcopy(example_tsds)
+
+    model = LinearPerSegmentModel()
+    transforms = [AddConstTransform(in_column="target", value=10, inplace=True), DateFlagsTransform()]
+    pipeline = AutoRegressivePipeline(model=model, transforms=transforms, horizon=5)
+    pipeline.fit(example_tsds)
+    predictions_pipeline = pipeline.predict(ts=original_ts)
+
+    original_ts.fit_transform(transforms)
+    model.fit(original_ts)
+    predictions_manual = model.predict(original_ts)
+    predictions_manual.inverse_transform(transforms)
+
+    pd.testing.assert_frame_equal(predictions_pipeline.to_pandas(), predictions_manual.to_pandas())
 
 
 @pytest.mark.parametrize("load_ts", [True, False])

--- a/tests/test_pipeline/test_mixins.py
+++ b/tests/test_pipeline/test_mixins.py
@@ -122,6 +122,26 @@ def test_predict_mixin_predict_create_ts_called(start_timestamp, end_timestamp, 
         (pd.Timestamp("2020-01-05"), pd.Timestamp("2020-01-10")),
     ],
 )
+def test_predict_mixin_predict_inverse_transform_called(start_timestamp, end_timestamp, example_tsds):
+    ts = MagicMock()
+    mixin = make_mixin()
+
+    result = mixin._predict(
+        ts=ts, start_timestamp=start_timestamp, end_timestamp=end_timestamp, prediction_interval=False, quantiles=[]
+    )
+
+    result.inverse_transform.assert_called_once_with(transforms=mixin.transforms)
+
+
+@pytest.mark.parametrize(
+    "start_timestamp, end_timestamp",
+    [
+        (pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-01")),
+        (pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")),
+        (pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-10")),
+        (pd.Timestamp("2020-01-05"), pd.Timestamp("2020-01-10")),
+    ],
+)
 def test_predict_mixin_predict_determine_prediction_size_called(start_timestamp, end_timestamp, example_tsds):
     ts = MagicMock()
     mixin = make_mixin()

--- a/tests/test_pipeline/test_mixins.py
+++ b/tests/test_pipeline/test_mixins.py
@@ -130,7 +130,7 @@ def test_predict_mixin_predict_inverse_transform_called(start_timestamp, end_tim
         ts=ts, start_timestamp=start_timestamp, end_timestamp=end_timestamp, prediction_interval=False, quantiles=[]
     )
 
-    result.inverse_transform.assert_called_once_with(transforms=mixin.transforms)
+    result.inverse_transform.assert_called_once_with(mixin.transforms)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [x] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Look at #1295.

## Closing issues
Closes #1295.
