### PR TITLE
Add sorting by timestamp before the fit in catboost models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - 
-- 
+- Add sorting by timestamp before the fit in `CatBoostPerSegmentModel` and `CatBoostMultiSegmentModel` ([#1337](https://github.com/tinkoff-ai/etna/pull/1337))
 - Unify errors, warnings and checks in models ([#1312](https://github.com/tinkoff-ai/etna/pull/1312))
 - Remove upper limitation on version of numba ([#1321](https://github.com/tinkoff-ai/etna/pull/1321))
 

--- a/etna/models/catboost.py
+++ b/etna/models/catboost.py
@@ -79,6 +79,7 @@ class _CatBoostAdapter(BaseAdapter):
         :
             Fitted model
         """
+        df = df.sort_values(by="timestamp")
         features = df.drop(columns=["timestamp", "target"])
         target = df["target"]
         train_pool = self._prepare_pool(features, target.values)


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [x] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
Add sorting by timestamp before the fit in catboost models.

## Closing issues
Closes #792.