### PR TITLE
Speed up metrics computation by optimizing segment validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - 
-- 
+- Speed up metrics computation by optimizing segment validation ([#1338](https://github.com/tinkoff-ai/etna/pull/1338))
 - Unify errors, warnings and checks in models ([#1312](https://github.com/tinkoff-ai/etna/pull/1312))
 - Remove upper limitation on version of numba ([#1321](https://github.com/tinkoff-ai/etna/pull/1321))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - 
 - Add sorting by timestamp before the fit in `CatBoostPerSegmentModel` and `CatBoostMultiSegmentModel` ([#1337](https://github.com/tinkoff-ai/etna/pull/1337))
-- Speed up metrics computation by optimizing segment validation ([#1338](https://github.com/tinkoff-ai/etna/pull/1338))
+- Speed up metrics computation by optimizing segment validation, forbid NaNs during metrics computation ([#1338](https://github.com/tinkoff-ai/etna/pull/1338))
 - Unify errors, warnings and checks in models ([#1312](https://github.com/tinkoff-ai/etna/pull/1312))
 - Remove upper limitation on version of numba ([#1321](https://github.com/tinkoff-ai/etna/pull/1321))
 

--- a/etna/metrics/base.py
+++ b/etna/metrics/base.py
@@ -146,7 +146,7 @@ class Metric(AbstractMetric, BaseMixin):
             )
         for segment in segments_true:
             for name, dataset in zip(("y_true", "y_pred"), (y_true, y_pred)):
-                if "target" not in dataset.loc[:, segment].columns:
+                if (segment, "target") not in dataset.columns:
                     raise ValueError(
                         f"All the segments in {name} should contain 'target' column. Segment {segment} doesn't."
                     )
@@ -231,13 +231,12 @@ class Metric(AbstractMetric, BaseMixin):
         segments = set(y_true.df.columns.get_level_values("segment"))
         metrics_per_segment = {}
         for segment in segments:
+            df_true = y_true[:, segment, "target"]
+            df_pred = y_pred[:, segment, "target"]
             self._validate_timestamp_columns(
-                timestamp_true=y_true[:, segment, "target"].dropna().index,
-                timestamp_pred=y_pred[:, segment, "target"].dropna().index,
+                timestamp_true=df_true.dropna().index, timestamp_pred=df_pred.dropna().index
             )
-            metrics_per_segment[segment] = self.metric_fn(
-                y_true=y_true[:, segment, "target"].values, y_pred=y_pred[:, segment, "target"].values, **self.kwargs
-            )
+            metrics_per_segment[segment] = self.metric_fn(y_true=df_true.values, y_pred=df_pred.values, **self.kwargs)
         metrics = self._aggregate_metrics(metrics_per_segment)
         return metrics
 

--- a/etna/metrics/intervals_metrics.py
+++ b/etna/metrics/intervals_metrics.py
@@ -67,8 +67,10 @@ class Coverage(Metric, _QuantileMetricMixin):
         -------
             metric's value aggregated over segments or not (depends on mode)
         """
-        self._validate_segment_columns(y_true=y_true, y_pred=y_pred)
-        self._validate_timestamp_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_segments(y_true=y_true, y_pred=y_pred)
+        self._validate_target_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_index(y_true=y_true, y_pred=y_pred)
+        self._validate_nans(y_true=y_true, y_pred=y_pred)
         self._validate_tsdataset_quantiles(ts=y_pred, quantiles=self.quantiles)
 
         segments = set(y_true.df.columns.get_level_values("segment"))
@@ -132,8 +134,10 @@ class Width(Metric, _QuantileMetricMixin):
         -------
             metric's value aggregated over segments or not (depends on mode)
         """
-        self._validate_segment_columns(y_true=y_true, y_pred=y_pred)
-        self._validate_timestamp_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_segments(y_true=y_true, y_pred=y_pred)
+        self._validate_target_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_index(y_true=y_true, y_pred=y_pred)
+        self._validate_nans(y_true=y_true, y_pred=y_pred)
         self._validate_tsdataset_quantiles(ts=y_pred, quantiles=self.quantiles)
 
         segments = set(y_true.df.columns.get_level_values("segment"))

--- a/etna/metrics/intervals_metrics.py
+++ b/etna/metrics/intervals_metrics.py
@@ -68,15 +68,12 @@ class Coverage(Metric, _QuantileMetricMixin):
             metric's value aggregated over segments or not (depends on mode)
         """
         self._validate_segment_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_timestamp_columns(y_true=y_true, y_pred=y_pred)
         self._validate_tsdataset_quantiles(ts=y_pred, quantiles=self.quantiles)
 
         segments = set(y_true.df.columns.get_level_values("segment"))
         metrics_per_segment = {}
         for segment in segments:
-            self._validate_timestamp_columns(
-                timestamp_true=y_true[:, segment, "target"].dropna().index,
-                timestamp_pred=y_pred[:, segment, "target"].dropna().index,
-            )
             upper_quantile_flag = y_true[:, segment, "target"] <= y_pred[:, segment, f"target_{self.quantiles[1]:.4g}"]
             lower_quantile_flag = y_true[:, segment, "target"] >= y_pred[:, segment, f"target_{self.quantiles[0]:.4g}"]
 
@@ -136,15 +133,12 @@ class Width(Metric, _QuantileMetricMixin):
             metric's value aggregated over segments or not (depends on mode)
         """
         self._validate_segment_columns(y_true=y_true, y_pred=y_pred)
+        self._validate_timestamp_columns(y_true=y_true, y_pred=y_pred)
         self._validate_tsdataset_quantiles(ts=y_pred, quantiles=self.quantiles)
 
         segments = set(y_true.df.columns.get_level_values("segment"))
         metrics_per_segment = {}
         for segment in segments:
-            self._validate_timestamp_columns(
-                timestamp_true=y_true[:, segment, "target"].dropna().index,
-                timestamp_pred=y_pred[:, segment, "target"].dropna().index,
-            )
             upper_quantile = y_pred[:, segment, f"target_{self.quantiles[1]:.4g}"]
             lower_quantile = y_pred[:, segment, f"target_{self.quantiles[0]:.4g}"]
 

--- a/tests/test_metrics/test_metrics.py
+++ b/tests/test_metrics/test_metrics.py
@@ -120,17 +120,6 @@ def test_metrics_invalid_aggregation(metric_class):
 @pytest.mark.parametrize(
     "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
 )
-def test_invalid_timestamps(metric_class, two_dfs_with_different_timestamps):
-    """Check metrics behavior in case of invalid timeranges"""
-    forecast_df, true_df = two_dfs_with_different_timestamps
-    metric = metric_class()
-    with pytest.raises(ValueError, match="y_true and y_pred have different timestamps"):
-        _ = metric(y_true=true_df, y_pred=forecast_df)
-
-
-@pytest.mark.parametrize(
-    "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
-)
 def test_invalid_segments(metric_class, two_dfs_with_different_segments_sets):
     """Check metrics behavior in case of invalid segments sets"""
     forecast_df, true_df = two_dfs_with_different_segments_sets
@@ -142,7 +131,7 @@ def test_invalid_segments(metric_class, two_dfs_with_different_segments_sets):
 @pytest.mark.parametrize(
     "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
 )
-def test_invalid_segments_target(metric_class, train_test_dfs):
+def test_invalid_target_columns(metric_class, train_test_dfs):
     """Check metrics behavior in case of no target column in segment"""
     forecast_df, true_df = train_test_dfs
     columns = forecast_df.df.columns.to_list()
@@ -150,6 +139,41 @@ def test_invalid_segments_target(metric_class, train_test_dfs):
     forecast_df.df.columns = pd.MultiIndex.from_tuples(columns, names=["segment", "feature"])
     metric = metric_class()
     with pytest.raises(ValueError, match="All the segments in .* should contain 'target' column"):
+        _ = metric(y_true=true_df, y_pred=forecast_df)
+
+
+@pytest.mark.parametrize(
+    "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
+)
+def test_invalid_index(metric_class, two_dfs_with_different_timestamps):
+    """Check metrics behavior in case of invalid index"""
+    forecast_df, true_df = two_dfs_with_different_timestamps
+    metric = metric_class()
+    with pytest.raises(ValueError, match="y_true and y_pred have different timestamps"):
+        _ = metric(y_true=true_df, y_pred=forecast_df)
+
+
+@pytest.mark.parametrize(
+    "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
+)
+def test_invalid_nans_pred(metric_class, train_test_dfs):
+    """Check metrics behavior in case of nans in prediction."""
+    forecast_df, true_df = train_test_dfs
+    forecast_df.df.iloc[0, 0] = np.NaN
+    metric = metric_class()
+    with pytest.raises(ValueError, match="There are NaNs in y_pred"):
+        _ = metric(y_true=true_df, y_pred=forecast_df)
+
+
+@pytest.mark.parametrize(
+    "metric_class", (MAE, MSE, RMSE, MedAE, MSLE, MAPE, SMAPE, R2, Sign, MaxDeviation, DummyMetric, WAPE)
+)
+def test_invalid_nans_true(metric_class, train_test_dfs):
+    """Check metrics behavior in case of nans in true values."""
+    forecast_df, true_df = train_test_dfs
+    true_df.df.iloc[0, 0] = np.NaN
+    metric = metric_class()
+    with pytest.raises(ValueError, match="There are NaNs in y_true"):
         _ = metric(y_true=true_df, y_pred=forecast_df)
 
 

--- a/tests/test_metrics/test_metrics.py
+++ b/tests/test_metrics/test_metrics.py
@@ -121,7 +121,7 @@ def test_invalid_timestamps(metric_class, two_dfs_with_different_timestamps):
     """Check metrics behavior in case of invalid timeranges"""
     forecast_df, true_df = two_dfs_with_different_timestamps
     metric = metric_class()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="y_true and y_pred have different timestamps"):
         _ = metric(y_true=true_df, y_pred=forecast_df)
 
 
@@ -132,7 +132,7 @@ def test_invalid_segments(metric_class, two_dfs_with_different_segments_sets):
     """Check metrics behavior in case of invalid segments sets"""
     forecast_df, true_df = two_dfs_with_different_segments_sets
     metric = metric_class()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="There are segments in .* that are not in .*"):
         _ = metric(y_true=true_df, y_pred=forecast_df)
 
 
@@ -142,9 +142,11 @@ def test_invalid_segments(metric_class, two_dfs_with_different_segments_sets):
 def test_invalid_segments_target(metric_class, train_test_dfs):
     """Check metrics behavior in case of no target column in segment"""
     forecast_df, true_df = train_test_dfs
-    forecast_df.df.drop(columns=[("segment_1", "target")], inplace=True)
+    columns = forecast_df.df.columns.to_list()
+    columns[0] = ("segment_1", "not_target")
+    forecast_df.df.columns = pd.MultiIndex.from_tuples(columns, names=["segment", "feature"])
     metric = metric_class()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="All the segments in .* should contain 'target' column"):
         _ = metric(y_true=true_df, y_pred=forecast_df)
 
 


### PR DESCRIPTION
## Before submitting (must do checklist)

- [x] Did you read the [contribution guide](https://github.com/tinkoff-ai/etna/blob/master/CONTRIBUTING.md)?
- [ ] Did you update the docs? We use Numpy format for all the methods and classes.
- [ ] Did you write any new necessary tests?
- [x] Did you update the [CHANGELOG](https://github.com/tinkoff-ai/etna/blob/master/CHANGELOG.md)?
<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## Proposed Changes
1. Optimize `_validate_segment_columns`
2. Remove redundant dataframe selection in metrics computation. 

## Closing issues
Closes #1336.
